### PR TITLE
Remove lyon1 simple tag bundle

### DIFF
--- a/Resources/views/Layout/topBarItems.html.twig
+++ b/Resources/views/Layout/topBarItems.html.twig
@@ -1,5 +1,5 @@
 {% macro item(name, href, icon, attributes, title, dropdown, badge) %}
-    <li class="{% if dropdown is not empty %}dropdown{% endif %}{{ attributes | default(' ') | compareRoute(' active') | raw }}">
+    <li class="{% if dropdown is not empty %}dropdown{% endif %}{{ attributes | default('') | compareRoute(' active') | raw }}">
         <a
             {% if dropdown is not empty %}class="pointer-hand dropdown-toggle" data-toggle="dropdown"{% endif %}
             {% if href is not empty %}href="{{ href }}"{% endif %}

--- a/Twig/HomeExtension.php
+++ b/Twig/HomeExtension.php
@@ -4,7 +4,6 @@ namespace Claroline\CoreBundle\Twig;
 
 use JMS\DiExtraBundle\Annotation as DI;
 use Symfony\Bundle\FrameworkBundle\Translation\Translator;
-use Symfony\Component\DependencyInjection\Container;
 
 /**
  * @DI\Service
@@ -12,7 +11,6 @@ use Symfony\Component\DependencyInjection\Container;
  */
 class HomeExtension extends \Twig_Extension
 {
-    /** @var Container */
     protected $container;
 
     /**
@@ -20,7 +18,7 @@ class HomeExtension extends \Twig_Extension
      *     "container" = @DI\Inject("service_container")
      * })
      */
-    public function __construct(Container $container)
+    public function __construct($container)
     {
         $this->container = $container;
     }


### PR DESCRIPTION
Don't know why it is still here as I already remove it a long time ago but hey git happiness \o/

As far as I'm concerned this bundle is not used so => out
