### PR TITLE
Remove useless code

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,6 +58,6 @@
     },
     "target-dir": "Claroline/CoreBundle",
     "extra": {
-        "dbVersion": "20130919105916"
+        "dbVersion": "20130915203447"
     }
 }


### PR DESCRIPTION
As the ZenstrcuFormBundle provide a way to configure the control-width and the label-width this code is now useless and can be a source of conflict.
