### PR TITLE
Check workspace when whecking badge awarding rules respect

### DIFF
--- a/Badge/BadgeRuleChecker.php
+++ b/Badge/BadgeRuleChecker.php
@@ -6,6 +6,7 @@ use Claroline\CoreBundle\Entity\Badge\Badge;
 use Claroline\CoreBundle\Entity\Badge\BadgeRule;
 use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Entity\Log\Log;
+use Claroline\CoreBundle\Entity\Workspace\AbstractWorkspace;
 use Claroline\CoreBundle\Repository\Log\LogRepository;
 
 class BadgeRuleChecker
@@ -21,14 +22,16 @@ class BadgeRuleChecker
     }
 
     /**
-     * @param BadgeRule $badgeRule
-     * @param User      $user
+     * @param AbstractWorkspace|null $workspace
+     * @param BadgeRule              $badgeRule
+     * @param User                   $user
      *
      * @return bool|Log[]
      */
-    public function checkRule(BadgeRule $badgeRule, User $user)
+    public function checkRule($workspace, BadgeRule $badgeRule, User $user)
     {
-        $associatedLogs = $this->logRepository->findByBadgeRuleAndUser($badgeRule, $user);
+        /** @var \Claroline\CoreBundle\Entity\Log\Log[] $associatedLogs */
+        $associatedLogs = $this->logRepository->findByWorkspaceBadgeRuleAndUser($workspace, $badgeRule, $user);
 
         $checkRule = false;
 
@@ -55,7 +58,7 @@ class BadgeRuleChecker
         if (0 < count($badgeRules)) {
             foreach ($badgeRules as $badgeRule) {
 
-                $checkedLogs = $this->checkRule($badgeRule, $user);
+                $checkedLogs = $this->checkRule($badge->getWorkspace(), $badgeRule, $user);
 
                 if (false === $checkedLogs) {
                     $isChecked = false;

--- a/Entity/Badge/Badge.php
+++ b/Entity/Badge/Badge.php
@@ -499,6 +499,14 @@ class Badge
     }
 
     /**
+     * @return AbstractWorkspace
+     */
+    public function getWorkspace()
+    {
+        return $this->workspace;
+    }
+
+    /**
      * @param UploadedFile $file
      *
      * @return Badge

--- a/Resources/exporter/Badge/export.json.twig
+++ b/Resources/exporter/Badge/export.json.twig
@@ -1,5 +1,5 @@
 {
     "id": "{{ entity.id }}",
-    "label": "{{ entity.name }}",
-    "name": "{{ entity.name }}",
+    "label": "{{ entity.name|raw }}",
+    "name": "{{ entity.name|raw }}",
 }

--- a/Tests/Badge/BadgeRuleCheckerTest.php
+++ b/Tests/Badge/BadgeRuleCheckerTest.php
@@ -5,6 +5,7 @@ namespace Claroline\CoreBundle\Badge;
 use Claroline\CoreBundle\Entity\Badge\Badge;
 use Claroline\CoreBundle\Entity\Badge\BadgeRule;
 use Claroline\CoreBundle\Entity\Log\Log;
+use Claroline\CoreBundle\Entity\Workspace\SimpleWorkspace;
 use \Mockery as m;
 use Claroline\CoreBundle\Entity\User;
 use Claroline\CoreBundle\Library\Testing\MockeryTestCase;
@@ -22,16 +23,13 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $rule                   = new BadgeRule();
         $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($rule, $user) {
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($rule, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $rule, $user)
                 ->andReturn(array());
         });
         $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
 
-        /** @var badge $badge */
-        $badge = new Badge();
-
-        $this->assertFalse($this->badgeRuleChecker->checkRule($rule, $user));
+        $this->assertFalse($this->badgeRuleChecker->checkRule(null, $rule, $user));
     }
 
     public function testOneRuleMatchOneLog()
@@ -41,13 +39,13 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $rule                   = new BadgeRule();
         $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($log, $rule, $user) {
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($rule, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $rule, $user)
                 ->andReturn(array($log));
         });
         $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
 
-        $this->assertEquals(array($log), $this->badgeRuleChecker->checkRule($rule, $user));
+        $this->assertEquals(array($log), $this->badgeRuleChecker->checkRule(null, $rule, $user));
     }
 
     public function testOneRuleMatchTwoLog()
@@ -58,13 +56,13 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $rule                   = new BadgeRule();
         $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($rule, $user, $log, $log2) {
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($rule, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $rule, $user)
                 ->andReturn(array($log, $log2));
         });
         $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
 
-        $this->assertEquals(array($log, $log2), $this->badgeRuleChecker->checkRule($rule, $user));
+        $this->assertEquals(array($log, $log2), $this->badgeRuleChecker->checkRule(null, $rule, $user));
     }
 
     public function testTwoRuleMatchNoLog()
@@ -74,12 +72,12 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $badgeRule2             = new BadgeRule();
         $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($badgeRule, $badgeRule2, $user) {
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($badgeRule, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $badgeRule, $user)
                 ->andReturn(array());
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($badgeRule2, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $badgeRule2, $user)
                 ->andReturn(array());
         });
         $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
@@ -88,7 +86,8 @@ class BadgeRuleCheckerTest extends MockeryTestCase
 
         /** @var badge $badge */
         $badge = new Badge();
-        $badge->setBadgeRules($badgeRules);
+        $badge
+            ->setBadgeRules($badgeRules);
 
         $this->assertFalse($this->badgeRuleChecker->checkBadge($badge, $user));
     }
@@ -100,12 +99,12 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $badgeRule2             = new BadgeRule();
         $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($badgeRule, $badgeRule2, $user) {
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($badgeRule, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $badgeRule, $user)
                 ->andReturn(array(new Log()));
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($badgeRule2, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $badgeRule2, $user)
                 ->andReturn(array());
         });
         $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
@@ -128,12 +127,12 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $log2                   = new Log();
         $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($badgeRule, $badgeRule2, $user, $log, $log2) {
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($badgeRule, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $badgeRule, $user)
                 ->andReturn(array($log));
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
-                ->with($badgeRule2, $user)
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with(null, $badgeRule2, $user)
                 ->andReturn(array($log2));
         });
         $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
@@ -154,7 +153,7 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $log2                   = new Log();
         $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($user, $log, $log2) {
             $mock
-                ->shouldReceive('findByBadgeRuleAndUser')
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
                 ->never();
         });
         $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
@@ -163,5 +162,145 @@ class BadgeRuleCheckerTest extends MockeryTestCase
         $badge = new Badge();
 
         $this->assertEquals(false, $this->badgeRuleChecker->checkBadge($badge, $user));
+    }
+
+    public function testOneRuleMatchNoLogOnWorkspace()
+    {
+        $workspace              = new SimpleWorkspace();
+        $user                   = new User();
+        $badgeRule              = new BadgeRule();
+        $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($workspace, $badgeRule, $user) {
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule, $user)
+                ->andReturn(array());
+        });
+        $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
+
+        $this->assertFalse($this->badgeRuleChecker->checkRule($workspace, $badgeRule, $user));
+    }
+
+    public function testOneRuleMatchOneLogOnWorkspace()
+    {
+        $workspace              = new SimpleWorkspace();
+        $log                    = new Log();
+        $user                   = new User();
+        $badgeRule              = new BadgeRule();
+        $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($workspace, $log, $badgeRule, $user) {
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule, $user)
+                ->andReturn(array($log));
+        });
+        $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
+
+        $this->assertEquals(array($log), $this->badgeRuleChecker->checkRule($workspace, $badgeRule, $user));
+    }
+
+    public function testOneRuleMatchTwoLogOnWorkspace()
+    {
+        $workspace              = new SimpleWorkspace();
+        $log                    = new Log();
+        $log2                   = new Log();
+        $user                   = new User();
+        $badgeRule                   = new BadgeRule();
+        $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($workspace, $badgeRule, $user, $log, $log2) {
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule, $user)
+                ->andReturn(array($log, $log2));
+        });
+        $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
+
+        $this->assertEquals(array($log, $log2), $this->badgeRuleChecker->checkRule($workspace, $badgeRule, $user));
+    }
+
+    public function testTwoRuleMatchNoLogOnWorkspace()
+    {
+        $workspace              = new SimpleWorkspace();
+        $user                   = new User();
+        $badgeRule              = new BadgeRule();
+        $badgeRule2             = new BadgeRule();
+        $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($workspace, $badgeRule, $badgeRule2, $user) {
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule, $user)
+                ->andReturn(array());
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule2, $user)
+                ->andReturn(array());
+        });
+        $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
+
+        $badgeRules = array($badgeRule, $badgeRule2);
+
+        /** @var badge $badge */
+        $badge = new Badge();
+        $badge
+            ->setBadgeRules($badgeRules)
+            ->setWorkspace($workspace);
+
+        $this->assertFalse($this->badgeRuleChecker->checkBadge($badge, $user));
+    }
+
+    public function testTwoRuleMatchOneLogOnWorkspace()
+    {
+        $workspace              = new SimpleWorkspace();
+        $user                   = new User();
+        $badgeRule              = new BadgeRule();
+        $badgeRule2             = new BadgeRule();
+        $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($workspace, $badgeRule, $badgeRule2, $user) {
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule, $user)
+                ->andReturn(array(new Log()));
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule2, $user)
+                ->andReturn(array());
+        });
+        $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
+
+        $badgeRules = array($badgeRule, $badgeRule2);
+
+        /** @var badge $badge */
+        $badge = new Badge();
+        $badge
+            ->setBadgeRules($badgeRules)
+            ->setWorkspace($workspace);
+
+        $this->assertFalse($this->badgeRuleChecker->checkBadge($badge, $user));
+    }
+
+    public function testTwoRuleMatchTwoLogOnWorkspace()
+    {
+        $workspace              = new SimpleWorkspace();
+        $user                   = new User();
+        $badgeRule              = new BadgeRule();
+        $badgeRule2             = new BadgeRule();
+        $log                    = new Log();
+        $log2                   = new Log();
+        $this->logRepository    = m::mock('Claroline\CoreBundle\Repository\Log\LogRepository', function($mock) use($workspace, $badgeRule, $badgeRule2, $user, $log, $log2) {
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule, $user)
+                ->andReturn(array($log));
+            $mock
+                ->shouldReceive('findByWorkspaceBadgeRuleAndUser')
+                ->with($workspace, $badgeRule2, $user)
+                ->andReturn(array($log2));
+        });
+        $this->badgeRuleChecker = new BadgeRuleChecker($this->logRepository);
+
+        $badgeRules = array($badgeRule, $badgeRule2);
+
+        /** @var badge $badge */
+        $badge = new Badge();
+        $badge
+            ->setBadgeRules($badgeRules)
+            ->setWorkspace($workspace);
+
+        $this->assertEquals(array($log, $log2), $this->badgeRuleChecker->checkBadge($badge, $user));
     }
 }

--- a/Tests/Repository/Log/LogRepositoryTest.php
+++ b/Tests/Repository/Log/LogRepositoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Claroline\CoreBundle\Repository\Log;
+
+use Claroline\CoreBundle\Entity\Badge\BadgeRule;
+use Claroline\CoreBundle\Entity\User;
+use Claroline\CoreBundle\Entity\Workspace\SimpleWorkspace;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Query\Parameter;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+class LogRepositoryTest extends WebTestCase
+{
+    /**
+     * @var \Doctrine\ORM\EntityManager
+     */
+    private $entityManager;
+
+    /** @var \Claroline\CoreBundle\Repository\Log\LogRepository */
+    private $logRepository;
+
+    public function setUp()
+    {
+        static::$kernel = static::createKernel();
+        static::$kernel->boot();
+        $this->entityManager = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
+        $this->logRepository = $this->entityManager->getRepository('ClarolineCoreBundle:Log\Log');
+    }
+
+    public function testFindByWorkspaceBadgeRuleAndUserWithNoWorkspace()
+    {
+        $badgeRule = new BadgeRule();
+        $user      = new User();
+        $query     = $this->logRepository->findByWorkspaceBadgeRuleAndUser(null, $badgeRule, $user, false);
+        $expectedQuery = 'SELECT c0_.id AS id0, c0_.action AS action1, c0_.date_log AS date_log2, c0_.short_date_log AS short_date_log3, c0_.details AS details4, c0_.doer_type AS doer_type5, c0_.doer_ip AS doer_ip6, c0_.tool_name AS tool_name7, c0_.is_displayed_in_admin AS is_displayed_in_admin8, c0_.is_displayed_in_workspace AS is_displayed_in_workspace9, c0_.doer_id AS doer_id10, c0_.receiver_id AS receiver_id11, c0_.receiver_group_id AS receiver_group_id12, c0_.owner_id AS owner_id13, c0_.workspace_id AS workspace_id14, c0_.resourceNode_id AS resourceNode_id15, c0_.resource_type_id AS resource_type_id16, c0_.role_id AS role_id17 FROM claro_log c0_ WHERE c0_.action = ? AND c0_.doer_id = ? ORDER BY c0_.date_log ASC';
+        $this->assertEquals($expectedQuery, $query->getSQL());
+
+        $actionParameter    = new Parameter('action', $badgeRule->getAction());
+        $doerParameter      = new Parameter('doer', $user);
+        $expectedParameters = new ArrayCollection();
+        $expectedParameters->add($actionParameter);
+        $expectedParameters->add($doerParameter);
+
+        $this->assertEquals($expectedParameters, $query->getParameters());
+    }
+
+    public function testFindByWorkspaceBadgeRuleAndUserWithWorkspace()
+    {
+        $badgeRule = new BadgeRule();
+        $user      = new User();
+        $workspace = new SimpleWorkspace();
+
+        $query     = $this->logRepository->findByWorkspaceBadgeRuleAndUser($workspace, $badgeRule, $user, false);
+        $expectedQuery = 'SELECT c0_.id AS id0, c0_.action AS action1, c0_.date_log AS date_log2, c0_.short_date_log AS short_date_log3, c0_.details AS details4, c0_.doer_type AS doer_type5, c0_.doer_ip AS doer_ip6, c0_.tool_name AS tool_name7, c0_.is_displayed_in_admin AS is_displayed_in_admin8, c0_.is_displayed_in_workspace AS is_displayed_in_workspace9, c0_.doer_id AS doer_id10, c0_.receiver_id AS receiver_id11, c0_.receiver_group_id AS receiver_group_id12, c0_.owner_id AS owner_id13, c0_.workspace_id AS workspace_id14, c0_.resourceNode_id AS resourceNode_id15, c0_.resource_type_id AS resource_type_id16, c0_.role_id AS role_id17 FROM claro_log c0_ WHERE c0_.action = ? AND c0_.doer_id = ? AND c0_.workspace_id = ? ORDER BY c0_.date_log ASC';
+        $this->assertEquals($expectedQuery, $query->getSQL());
+
+        $actionParameter         = new Parameter('action', $badgeRule->getAction());
+        $doerParameter           = new Parameter('doer', $user);
+        $workspaceParameter      = new Parameter('workspace', $workspace);
+        $expectedParameters = new ArrayCollection();
+        $expectedParameters->add($actionParameter);
+        $expectedParameters->add($doerParameter);
+        $expectedParameters->add($workspaceParameter);
+
+        $this->assertEquals($expectedParameters, $query->getParameters());
+    }
+}


### PR DESCRIPTION
Add restriction on wokrspace for checking if rules are respected when checking for badge awarding.

If the badge has a workspace we check il the action occured on this wokrspace, if not rules are not respected.
