### PR TITLE
Include just uses components instead of all jquery-ui

### DIFF
--- a/Resources/views/Resource/configResourcesManager.html.twig
+++ b/Resources/views/Resource/configResourcesManager.html.twig
@@ -1,4 +1,6 @@
 {% if includeDependencies %}
+    <link rel='stylesheet' type='text/css' href='{{ asset('bundles/frontend/jquery/plugin/datepicker/css/datepicker.css')}}'>
+    
     {% javascripts
         vars=["locale"]
         "@ClarolineCoreBundle/Resources/views/Resource/breadcrumbs.html.twigjs"
@@ -18,6 +20,7 @@
     <script type='text/javascript' src='{{ asset('bundles/frontend/jquery/jquery-ui-1.9.2/components/jquery.ui.widget.min.js') }}' ></script>
     <script type='text/javascript' src='{{ asset('bundles/frontend/jquery/jquery-ui-1.9.2/components/jquery.ui.mouse.min.js') }}' ></script>
     <script type='text/javascript' src='{{ asset('bundles/frontend/jquery/jquery-ui-1.9.2/components/jquery.ui.sortable.min.js') }}' ></script>
+    <script type="text/javascript" src="{{ asset('bundles/frontend/jquery/plugin/datepicker/js/bootstrap-datepicker.js') }}"></script>
     <script type="text/javascript" src="{{ asset('bundles/clarolinecore/js/resource/manager.js') }}"></script>
 {% endif %}
 <div id="picker-wrapper"></div>

--- a/Resources/views/Tool/workspace/resource_manager/resources.html.twig
+++ b/Resources/views/Tool/workspace/resource_manager/resources.html.twig
@@ -48,7 +48,7 @@
     <script type="text/javascript" src="{{ asset('bundles/frontend/underscore/underscore-1.3.3.min.js') }}"></script>
     <script type="text/javascript" src="{{ asset('bundles/frontend/backbone/backbone-0.9.2.min.js') }}"></script>
     <script type="text/javascript" src="{{ asset('bundles/frontend/jquery/jquery-ui-1.9.2.custom/js/jquery-ui-1.9.2.custom.js') }}"></script>
-    <script type="text/javascript" src="{{ asset('bundles/frontend/jquery/plugin/datepicker/js/bootstrap-datepicker.js') }}" type="text/javascript"></script>
+    <script type="text/javascript" src="{{ asset('bundles/frontend/jquery/plugin/datepicker/js/bootstrap-datepicker.js') }}"></script>
     <script type="text/javascript" src="{{ asset('bundles/clarolinecore/js/resource/manager.js') }}"></script>
     <script type="text/javascript" src="{{ url('bazinga_exposetranslation_js', { 'domain_name': 'resource' }) }}"></script>
     {% render controller('ClarolineCoreBundle:ResourceType:initPicker', {'includeDependencies': false}) %}


### PR DESCRIPTION
It's a good way to include just the files we need instead of include entire library.
