### PR TITLE
Remove dispatching event for logging custom action call in the core

### DIFF
--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -287,8 +287,6 @@ class ResourceController
             array($this->resourceManager->getResourceFromNode($node))
         );
 
-        $this->dispatcher->dispatch('log', 'Log\LogResourceCustom', array($node, $action));
-
         return $event->getResponse();
     }
 

--- a/Tests/Controller/ResourceControllerTest.php
+++ b/Tests/Controller/ResourceControllerTest.php
@@ -55,9 +55,6 @@ class ResourceControllerTest extends MockeryTestCase
         $controller->shouldReceive('checkAccess')
             ->with('decoderaction', anInstanceOf('Claroline\CoreBundle\Library\Resource\ResourceCollection'));
         $this->dispatcher->shouldReceive('dispatch')->once()
-            ->with('log', 'Log\LogResourceCustom', array($node, $action))
-            ->andReturn($customActionEvent);
-        $this->dispatcher->shouldReceive('dispatch')->once()
             ->with('action_type', 'CustomActionResource', array($res))
             ->andReturn($customActionEvent);
         $response = new \Symfony\Component\HttpFoundation\Response;


### PR DESCRIPTION
 It's plugins responsability to disptach event for logging because it will disptach only if no error occured, in the core it was always dispatch.
