### PR TITLE
Help block on form is not meant to display error

### DIFF
--- a/Resources/views/less/layout.less
+++ b/Resources/views/less/layout.less
@@ -691,6 +691,11 @@ div.pagination {
 /* MISC */
 /********/
 
+form.has-error .help-block {
+    .alert;
+    .alert-danger;
+}
+
 .content-scroll {
     width: 100%;
     height: 150px;


### PR DESCRIPTION
I don't see any reasons for putting all `help-block` in form as alert block. @solispauwels

Eventually put this instead in layout.less, I don't know what's that code for:

``` css
form.has-error .help-block {
    .alert;
    .alert-danger;
}
```

But for sure not for all `help-block`.
