### PR TITLE
Use right variable name for checking if user has been notified by email

### DIFF
--- a/Manager/MessageManager.php
+++ b/Manager/MessageManager.php
@@ -163,7 +163,7 @@ class MessageManager
             $userMessage->setMessage($message);
             $this->om->persist($userMessage);
 
-            if ($user->isMailNotified()) {
+            if ($filteredUser->isMailNotified()) {
                 $mailNotifiedUsers[] = $filteredUser;
             }
         }


### PR DESCRIPTION
I got the error when lauching raw_install script but I think this could happened somewhere else.
