### PR TITLE
Correct use of the message manager in the loadMessageData fixture class

### DIFF
--- a/DataFixtures/Optional/LoadMessagesData.php
+++ b/DataFixtures/Optional/LoadMessagesData.php
@@ -54,11 +54,7 @@ class LoadMessagesData extends LoggableFixture implements ContainerAwareInterfac
             $parent = isset($data['parent']) ?
                 $this->getReference('message/' . $data['parent']) :
                 null;
-            $messageManager->send(
-                $this->getReference('user/' . $data['from']),
-                $message,
-                $parent
-            );
+            $messageManager->send($message);
             $this->addReference('message/' . $data['object'], $message);
         }
 

--- a/Manager/MessageManager.php
+++ b/Manager/MessageManager.php
@@ -138,8 +138,6 @@ class MessageManager
             $workspaceReceivers = $this->workspaceRepo->findWorkspacesByCode($workspaceCodes);
         }
 
-        $message->setSender($message->getSender());
-
         if (null !== $message->getParent()) {
             $message->setParent($message->getParent());
         }


### PR DESCRIPTION
When launching raw_install I get this error:

> PHP Catchable fatal error:  Argument 1 passed to Claroline\CoreBundle\Manager\MessageManager::send() must be an instance of Claroline\CoreBundle\Entity\Message, instance of Claroline\CoreBundle\Entity\User given, called in /home/maxime/workspace/Claroline/vendor/claroline/core-bundle/Claroline/CoreBundle/DataFixtures/Optional/LoadMessagesData.php on line 61 and defined in /home/maxime/workspace/Claroline/vendor/claroline/core-bundle/Claroline/CoreBundle/Manager/MessageManager.php on line 101

So here is the patch for this error.
