### PR TITLE
Require mcrypt php extension in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     ],
     "require": {
         "php": ">=5.4.1",
+        "ext-mcrypt": "*",
         "symfony/symfony": "2.4.0",
         "symfony/assetic-bundle": "~2.3",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
As we talk about it last week I add it to the composer.json for enhance installation process.
