### PR TITLE
add twig text_extension

### DIFF
--- a/DependencyInjection/ClarolineCoreExtension.php
+++ b/DependencyInjection/ClarolineCoreExtension.php
@@ -30,5 +30,6 @@ class ClarolineCoreExtension extends Extension
         $loader = new YamlFileLoader($container, $locator);
         $loader->load('parameters.yml');
         $loader->load('services.yml');
+        $loader->load('twig.yml');
     }
 }

--- a/Resources/config/twig.yml
+++ b/Resources/config/twig.yml
@@ -1,0 +1,5 @@
+services:
+    twig.extension.text:
+       class: Twig_Extensions_Extension_Text
+       tags:
+            - { name: twig.extension }


### PR DESCRIPTION
I saw this in some bundles

```
{{ object.str | length > 40 ? object.str | slice(0, 40) ~ '...' :object.str }} 
```

It may be usefull to load twig text extension ( http://twig.sensiolabs.org/doc/extensions/text.html ) in the core in order to get this (and be profitable everywhere):

```
{{ object.str | truncate(40) }}
```
