### PR TITLE
Using refesh instead of just dumpAssets in claroline:update command

### DIFF
--- a/Command/PlatformUpdateCommand.php
+++ b/Command/PlatformUpdateCommand.php
@@ -45,7 +45,7 @@ class PlatformUpdateCommand extends ContainerAwareCommand
             }
         );
         $installer->installFromOperationFile();
-        $refresher->dumpAssets($this->getContainer()->getParameter('kernel.environment'));
+        $refresher->refresh($this->getContainer()->getParameter('kernel.environment'), true);
         MaintenanceHandler::disableMaintenance();
     }
 }


### PR DESCRIPTION
What do you think about that?

On our platform theme has to be regenerated for the last ersion, but it's not automatically done.
To avoid such issue maybe always do this can be a good idea.
