### PR TITLE
Add log on the updater that assign public url to users

### DIFF
--- a/Library/Installation/Updater/Updater021200.php
+++ b/Library/Installation/Updater/Updater021200.php
@@ -77,6 +77,7 @@ class Updater021200
         $users = $userRepository->findByPublicUrl(null);
 
         $this->log('User to update ' . count($users) . ' - ' . date('Y/m/d H:i:s'));
+        $this->log('It may take a while to process, go grab a coffee.');
 
         /** @var \Claroline\CoreBundle\Manager\UserManager $userManager */
         $userManager = $this->container->get('claroline.manager.user_manager');


### PR DESCRIPTION
I know it won't be useful for those who already have updated their platform, but for other it might be useful.
