### PR TITLE
Add block in global layout for allowing child template to define its own container for content

### DIFF
--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -94,11 +94,12 @@
             {% endif %}
         {% endif %}
 
-       {% block impersonation %}
+        {% block impersonation %}
             {% if has_role('ROLE_USURPATE_WORKSPACE_ROLE') or is_impersonated() %}
                 {% render controller('ClarolineCoreBundle:Layout:renderWarningImpersonation') %}
             {% endif %}
         {% endblock %}
+        {% block content_container %}
         <div class="container">
             <div class="row">
                 <div class="col-md-12">
@@ -112,6 +113,7 @@
             </div>
         </div>
         <div id="push"></div>
+        {% endblock %}
     </div>
    {% block footer %}
         {% if not is_path_mode %}


### PR DESCRIPTION
I'm needing it because I don't need all of this markup for displaying a portfolio.
