### PR TITLE
Rename parameter for claro_public_profile_view route from userId to publicUrl

### DIFF
--- a/Resources/views/Notification/notification_item.html.twig
+++ b/Resources/views/Notification/notification_item.html.twig
@@ -3,7 +3,7 @@
 
 {% block notificationText %}
     {% if notification.userId is not empty and notification.details.doer is defined %}
-        <a href="{{ path('claro_public_profile_view', {'userId' : notification.userId}) }}"><strong>{{ notification.details.doer.firstName ~ ' ' ~ notification.details.doer.lastName }}</strong></a>
+        <a href="{{ path('claro_public_profile_view', {'publicId' : notification.userId}) }}"><strong>{{ notification.details.doer.firstName ~ ' ' ~ notification.details.doer.lastName }}</strong></a>
     {% else %}
         <strong>{{ systemName }}</strong>
     {% endif %}


### PR DESCRIPTION
This route is available with public url or user ID.
But the parameter to do this is publicUrl, User ID is here just for old notification, backward compatibility.
