### PR TITLE
Hide tab widget content when set to hidden

### DIFF
--- a/Resources/public/js/widget/widgetsWithConfig.js
+++ b/Resources/public/js/widget/widgetsWithConfig.js
@@ -137,12 +137,17 @@
                     visibilityBtn.find('i').addClass('icon-eye-close');
                     visibilityBtn.find('span').html(translator.get('platform:hide'));
                     currentElement.find('.panel-title').first().removeClass('strike');
+                    
+                    currentElement.find('.panel-body').first().show('slow');
                 } else {
                     visibilityBtn.attr('visiblility-value', 'invisible');
                     visibilityBtn.find('i').removeClass('icon-eye-close');
                     visibilityBtn.find('i').addClass('icon-eye-open');
                     visibilityBtn.find('span').html(translator.get('platform:display'));
                     currentElement.find('.panel-title').first().addClass('strike');
+                    
+                    currentElement.find('.panel-body').first().hide('slow');
+                    
                 }
             }
         });

--- a/Resources/views/Widget/widgetsWithConfig.html.twig
+++ b/Resources/views/Widget/widgetsWithConfig.html.twig
@@ -26,8 +26,8 @@
                         </div>
                     </div>
                     <div id="collapse{{ widgetInstance.getId() }}" class="collapse-widget collapse in">
-                        <div class="panel-body widget-instance-view">
-                           {{ widgetDatas.content|raw }}
+                        <div class="panel-body widget-instance-view" {% if not widgetHomeTabConfig.isVisible() %} style="display: none;" {% endif %}>                           
+                            {{ widgetDatas.content|raw }}
                        </div>
                        <div class="panel-body widget-instance-edition hide"></div>
                     </div>


### PR DESCRIPTION
When we set a tab widget to hidden we find it more clear to hide the content of the widget and leave only the widget title and config button
