### PR TITLE
Setting issuer when badge is awarded

### DIFF
--- a/Controller/Administration/BadgeController.php
+++ b/Controller/Administration/BadgeController.php
@@ -194,10 +194,11 @@ class BadgeController extends Controller
     /**
      * @Route("/award/{slug}", name="claro_admin_badges_award")
      * @ParamConverter("badge", converter="badge_converter")
+     * @ParamConverter("loggedUser", options={"authenticatedUser" = true})
      *
      * @Template()
      */
-    public function awardAction(Request $request, Badge $badge)
+    public function awardAction(Request $request, Badge $badge, User $loggedUser)
     {
         $this->checkOpen();
 
@@ -229,7 +230,7 @@ class BadgeController extends Controller
 
                     /** @var \Claroline\CoreBundle\Manager\BadgeManager $badgeManager */
                     $badgeManager = $this->get('claroline.manager.badge');
-                    $awardedBadge = $badgeManager->addBadgeToUsers($badge, $users);
+                    $awardedBadge = $badgeManager->addBadgeToUsers($badge, $users, $loggedUser);
 
                     $flashMessageType = 'error';
 

--- a/Controller/Badge/Tool/WorkspaceController.php
+++ b/Controller/Badge/Tool/WorkspaceController.php
@@ -227,9 +227,10 @@ class WorkspaceController extends Controller
      *     options={"id" = "workspaceId"}
      * )
      * @ParamConverter("badge", converter="badge_converter")
+     * @ParamConverter("loggedUser", options={"authenticatedUser" = true})
      * @Template
      */
-    public function awardAction(Request $request, AbstractWorkspace $workspace, Badge $badge)
+    public function awardAction(Request $request, AbstractWorkspace $workspace, Badge $badge, User $loggedUser)
     {
         if (null === $badge->getWorkspace()) {
             throw $this->createNotFoundException("No badge found.");
@@ -261,7 +262,7 @@ class WorkspaceController extends Controller
 
                     /** @var \Claroline\CoreBundle\Manager\BadgeManager $badgeManager */
                     $badgeManager = $this->get('claroline.manager.badge');
-                    $awardedBadge = $badgeManager->addBadgeToUsers($badge, $users);
+                    $awardedBadge = $badgeManager->addBadgeToUsers($badge, $users, $loggedUser);
 
                     $flashMessageType = 'error';
 

--- a/Entity/Badge/UserBadge.php
+++ b/Entity/Badge/UserBadge.php
@@ -62,7 +62,6 @@ class UserBadge
     /**
      * @var User $issuer
      *
-     * @Gedmo\Blameable(on="create")
      * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\User", inversedBy="issuedBadges")
      * @ORM\JoinColumn(name="issuer_id", referencedColumnName="id", nullable=true, onDelete="SET NULL")
     */
@@ -141,6 +140,18 @@ class UserBadge
     public function getIssuedAt()
     {
         return $this->issuedAt;
+    }
+
+    /**
+     * @param \Claroline\CoreBundle\Entity\User|null $issuer
+     *
+     * @return UserBadge
+     */
+    public function setIssuer($issuer)
+    {
+        $this->issuer = $issuer;
+
+        return $this;
     }
 
     /**

--- a/Manager/BadgeManager.php
+++ b/Manager/BadgeManager.php
@@ -50,17 +50,18 @@ class BadgeManager
     }
 
     /**
-     * @param Badge  $badge
-     * @param User[] $users
+     * @param Badge     $badge
+     * @param User[]    $users
+     * @param User|null $issuer
      *
      * @return int
      */
-    public function addBadgeToUsers(Badge $badge, $users)
+    public function addBadgeToUsers(Badge $badge, $users, $issuer = null)
     {
         $addedBadge = 0;
 
         foreach ($users as $user) {
-            if ($this->addBadgeToUser($badge, $user)) {
+            if ($this->addBadgeToUser($badge, $user, $issuer)) {
                 $addedBadge++;
             }
         }
@@ -69,13 +70,14 @@ class BadgeManager
     }
 
     /**
-     * @param Badge $badge
-     * @param User  $user
+     * @param Badge     $badge
+     * @param User      $user
+     * @param User|null $issuer
      *
      * @throws \Exception
      * @return bool
      */
-    public function addBadgeToUser(Badge $badge, User $user)
+    public function addBadgeToUser(Badge $badge, User $user, $issuer = null)
     {
         $badgeAwarded = false;
 
@@ -88,7 +90,8 @@ class BadgeManager
                 $userBadge = new UserBadge();
                 $userBadge
                     ->setBadge($badge)
-                    ->setUser($user);
+                    ->setUser($user)
+                    ->setIssuer($issuer);
 
                 if ($badge->isExpiring()) {
                     $userBadge->setExpiredAt($this->generateExpireDate($badge));


### PR DESCRIPTION
Before that when a badge was automatically awarded the issuer was the connected user, the one that made the action. Not very logic.

Now it's no one, I guess we can say it's the platform.
