### PR TITLE
Update composer.json: jms serializer bundle ~0.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "jms/security-extra-bundle": "~1.5.1",
         "jms/di-extra-bundle": "~1.4.0",
         "jms/twig-js-bundle": "dev-master",
-        "jms/serializer-bundle": "0.12.*",
+        "jms/serializer-bundle": "~0.12",
         "stof/doctrine-extensions-bundle": "~1.1.0",
         "gedmo/doctrine-extensions": "~2.3.1",
         "friendsofsymfony/jsrouting-bundle": "~1.2.1",


### PR DESCRIPTION
Allow plugins in claroline that use jms serializer bundle 0.13
Must be checked, but according to stefk, it should be ok.
