### PR TITLE
Changed core bundle table controls behavior (for messages)

### DIFF
--- a/Resources/public/js/table.js
+++ b/Resources/public/js/table.js
@@ -12,7 +12,7 @@
 /* global ValidationFooter */
 /* global ErrorFooter */
 
-(function () {
+(function() {
     'use strict';
 
     window.Claroline = window.Claroline || {};
@@ -53,15 +53,18 @@
      *
      * You can add a <select> whose id is "max-select". This will send the "max" parameter to the request.
      */
-    table.initialize = function (parameters) {
+    table.initialize = function(parameters) {
         var currentAction = '';
         createValidationBox();
         createErrorBox();
 
-        $('#search-button').click(function () {
+        // disable all elements with table-control class
+        $('.table-control').prop('disabled', true);
+
+        $('#search-button').click(function() {
             var search = document.getElementById('search-items-txt') ?
-                document.getElementById('search-items-txt').value :
-                '';
+                    document.getElementById('search-items-txt').value :
+                    '';
             var route;
 
             var max = findMaxPerPage();
@@ -85,11 +88,11 @@
             window.location.href = route;
         });
 
-        $('#search-items-txt').keypress(function (e) {
+        $('#search-items-txt').keypress(function(e) {
 
             var max = findMaxPerPage();
             if (max) {
-               parameters.route.search.parameters.max = parameters.route.normal.parameters.max = max;
+                parameters.route.search.parameters.max = parameters.route.normal.parameters.max = max;
             }
 
             if (e.keyCode === 13) {
@@ -111,12 +114,12 @@
         for (var key in parameters.route.action) {
             if (parameters.route.action.hasOwnProperty(key)) {
                 var btnClass = '.' + (
-                    parameters.route.action[key].btn === undefined ? 'action-button': parameters.route.action[key].btn
-                );
-                $(btnClass).click(function (e) {
+                        parameters.route.action[key].btn === undefined ? 'action-button' : parameters.route.action[key].btn
+                        );
+                $(btnClass).click(function(e) {
                     currentAction = $(e.currentTarget).attr('data-action');
                     var html = Twig.render(parameters.route.action[currentAction].confirmTemplate,
-                        {'nbItems': $('.chk-item:checked').length}
+                            {'nbItems': $('.chk-item:checked').length}
                     );
                     $('#table-modal .modal-body').html(html);
                     $('#table-modal').modal('show');
@@ -124,30 +127,30 @@
             }
         }
 
-        $('#modal-valid-button').on('click', function () {
+        $('#modal-valid-button').on('click', function() {
             if (currentAction) {
                 var queryString = {};
                 var i = 0;
                 var array = [];
-                $('.chk-item:checked').each(function (index, element) {
+                $('.chk-item:checked').each(function(index, element) {
                     array[i] = element.value;
                     i++;
                 });
                 queryString.ids = array;
                 var route = Routing.generate(
-                    parameters.route.action[currentAction].route,
-                    parameters.route.action[currentAction].parameters
-                );
-                var type =  parameters.route.action[currentAction].type === undefined ?
-                    'GET':
-                    parameters.route.action[currentAction].type;
+                        parameters.route.action[currentAction].route,
+                        parameters.route.action[currentAction].parameters
+                        );
+                var type = parameters.route.action[currentAction].type === undefined ?
+                        'GET' :
+                        parameters.route.action[currentAction].type;
                 route += '?' + $.param(queryString);
                 $.ajax({
                     url: route,
                     type: type,
-                    success: function () {
+                    success: function() {
                         if (parameters.route.action[currentAction].delete) {
-                            $('.chk-item:checked').each(function (index, element) {
+                            $('.chk-item:checked').each(function(index, element) {
                                 $(element).parent().parent().remove();
                             });
                         }
@@ -162,28 +165,45 @@
             }
         });
 
-        $('#check-all-items').click(function () {
+        $('#check-all-items').click(function() {
             if ($('#check-all-items').is(':checked')) {
-                $('.chk-item').attr('checked', true);
+                $('.chk-item').prop('checked', true);
+                // enable .table-control elements
+                $('.table-control').prop('disabled', false);
             }
             else {
-                $('.chk-item').attr('checked', false);
+                $('.chk-item').prop('checked', false);
+                 // disable .table-control elements
+                $('.table-control').prop('disabled', true);
             }
+        });
+
+        // checkboxes click event
+        $('.chk-item').on('click', function() {
+            $('.table-control').prop('disabled', true);
+            // if at least one checkbox is checked 
+            $('.chk-item').each(function() {
+                if ($(this).is(':checked')) {
+                    // enable .table-control elements
+                    $('.table-control').prop('disabled', false);
+                    return true;
+                }
+            });
         });
     };
 
     function createErrorBox() {
         var html = Twig.render(
-            ModalWindow,
-            {'footer': Twig.render(ErrorFooter), 'isHidden': true, 'modalId': 'error-modal', 'body': ''}
+                ModalWindow,
+                {'footer': Twig.render(ErrorFooter), 'isHidden': true, 'modalId': 'error-modal', 'body': ''}
         );
         $('body').append(html);
     }
 
     function createValidationBox() {
         var html = Twig.render(
-            ModalWindow,
-            {'footer': Twig.render(ValidationFooter), 'isHidden': true, 'modalId': 'table-modal', 'body': ''}
+                ModalWindow,
+                {'footer': Twig.render(ValidationFooter), 'isHidden': true, 'modalId': 'table-modal', 'body': ''}
         );
         $('body').append(html);
     }

--- a/Resources/views/Message/listReceived.html.twig
+++ b/Resources/views/Message/listReceived.html.twig
@@ -27,7 +27,7 @@
 
 {% macro displayControls() %}
     {% if app.user %}
-        <button class="btn btn-default action-button" data-action="remove">
+        <button class="btn btn-default action-button table-control" data-action="remove">
             <i class="fa fa-trash-o"></i>
             {{ 'delete'|trans({}, 'platform') }}
         </button>

--- a/Resources/views/Message/listRemoved.html.twig
+++ b/Resources/views/Message/listRemoved.html.twig
@@ -26,11 +26,11 @@
 {% endmacro %}
 {% macro displayControls() %}
     {% if app.user %}
-        <button class="btn btn-default action-delete-button" data-action="remove">
+        <button class="btn btn-default action-delete-button table-control" data-action="remove">
             <i class="fa fa-trash-o"></i>
             {{ 'delete'|trans({}, 'platform') }}
         </button>
-        <button class="btn btn-default action-restore-button" data-action="restore">
+        <button class="btn btn-default action-restore-button table-control" data-action="restore">
             <i class="fa fa-refresh"></i>
             {{ 'restore'|trans({}, 'platform') }}
         </button>

--- a/Resources/views/Message/listSent.html.twig
+++ b/Resources/views/Message/listSent.html.twig
@@ -27,7 +27,7 @@
 
 {% macro displayControls() %}
     {% if app.user %}
-        <button class="btn btn-default action-button" data-action="remove">
+        <button class="btn btn-default action-button table-control" data-action="remove">
             <i class="fa fa-trash-o"></i>
             {{ 'delete'|trans({}, 'platform') }}
         </button>


### PR DESCRIPTION
Buttons for Messages interfaces are now disabled if no item is checked.

Note that I changed `$('#check-all-items').click()` handler in `table.js` because using `$('item').attr()` is buggy on Chrome but using `$('item').prop()` works.
