### PR TITLE
If token provided by the symfony security component is null an error is raised

### DIFF
--- a/Form/Extension/CaptchaExtension.php
+++ b/Form/Extension/CaptchaExtension.php
@@ -37,8 +37,9 @@ class CaptchaExtension extends AbstractTypeExtension
         $ch = $this->container->get('claroline.config.platform_config_handler');
 
         if ($ch->getParameter('form_captcha')) {
-        //add captcha if anon.
-            if ($this->container->get('security.context')->getToken()->getUser() === 'anon.') {
+            $securityToken = $this->container->get('security.context')->getToken();
+
+            if (null !== $securityToken && $securityToken->getUser() === 'anon.') {
                 $builder->addEventListener(FormEvents::PRE_SET_DATA, function(FormEvent $event) {
                     $form = $event->getForm();
                     $data = $event->getData();


### PR DESCRIPTION
I don't know why but I was in this case and it leads in not being able to use the platform.
