### PR TITLE
Remove border on link in the notification dropdown menu

### DIFF
--- a/Resources/views/less/layout.less
+++ b/Resources/views/less/layout.less
@@ -318,7 +318,7 @@ body.iframe {
             right:0;
         }
 
-        li:not(:last-child) a {
+        li:not(:last-child) > a {
             border-right:1px solid darken(@navbar-inverse-bg, 5%) !important;
         }
     }


### PR DESCRIPTION
The border was set on every links, not a good way to do that.
