### PR TITLE
calendar.js - time format

### DIFF
--- a/Resources/public/js/tool/calendar.js
+++ b/Resources/public/js/tool/calendar.js
@@ -424,7 +424,7 @@
             editable: true,
             events: $('a#link').attr('href'),
             axisFormat: 'HH:mm',
-            timeFormat: 'H(:mm)',
+            timeFormat: 'H:mm',
             agenda: 'h:mm{ - h:mm}',
             '': 'h:mm{ - h:mm}',
             minTime: 0,


### PR DESCRIPTION
When adding an event with a begining time of 14h00 for exemple, the summary added to the calendar show [14 event title].
Changing `timeFormat: 'H(:mm)'` to  `timeFormat: 'H:mm'` seems to resolve the problem (not much documentation found in official website)
