### PR TITLE
Add resourceType condition when handling unicity on resourceName

### DIFF
--- a/Manager/ResourceManager.php
+++ b/Manager/ResourceManager.php
@@ -212,7 +212,7 @@ class ResourceManager
     public function getUniqueName(ResourceNode $node, ResourceNode $parent = null, $isCopy = false)
     {
         $candidateName = $node->getName();
-
+        $nodeType = $node->getResourceType();
         //if the parent is null, then it's a workspace root and the name is always correct
         //otherwise we fetch each workspace root with the findBy and the UnitOfWork won't be happy...
         if (!$parent) return $candidateName;
@@ -229,8 +229,9 @@ class ResourceManager
                 // same name is also incremented
                 continue;
             }
-
-            $siblingNames[] = $levelNode->getName();
+            if ($levelNode->getResourceType() === $nodeType) {
+                $siblingNames[] = $levelNode->getName();
+            }
         }
 
         if (!in_array($candidateName, $siblingNames)) {


### PR DESCRIPTION
Hey
what about checking node resourceType equality with his siblings before suffixing nodeName ? It would allow to have several resources of different types with the same name
