### PR TITLE
Adding forceArchive option.

### DIFF
--- a/Controller/ResourceController.php
+++ b/Controller/ResourceController.php
@@ -365,7 +365,14 @@ class ResourceController
      * @EXT\Route(
      *     "/download",
      *     name="claro_resource_download",
-     *     options={"expose"=true}
+     *     options={"expose"=true},
+     *     defaults ={"forceArchive"=false}
+     * )
+     * @EXT\Route(
+     *     "/download/{forceArchive}",
+     *     name="claro_resource_download",
+     *     options={"expose"=true},
+     *     requirements={"forceArchive" = "^(true|false|0|1)$"},
      * )
      * @EXT\ParamConverter(
      *     "nodes",
@@ -379,13 +386,14 @@ class ResourceController
      *
      * @param array $nodes
      *
+     * @param bool $forceArchive
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    public function downloadAction(array $nodes)
+    public function downloadAction(array $nodes, $forceArchive = false)
     {
         $collection = new ResourceCollection($nodes);
         $this->checkAccess('EXPORT', $collection);
-        $data = $this->resourceManager->download($nodes);
+        $data = $this->resourceManager->download($nodes, $forceArchive);
         $file = $data['file'];
         $fileName = $data['name'];
         $mimeType = $data['mimeType'];

--- a/Manager/ResourceManager.php
+++ b/Manager/ResourceManager.php
@@ -931,7 +931,7 @@ class ResourceManager
      *
      * @return array
      */
-    public function download(array $elements)
+    public function download(array $elements, $forceArchive = false)
     {
         $data = array();
 
@@ -944,7 +944,7 @@ class ResourceManager
         $archive->open($pathArch, \ZipArchive::CREATE);
         $nodes = $this->expandResources($elements);
 
-        if (count($nodes) === 1) {
+        if (!$forceArchive && count($nodes) === 1) {
             $event = $this->dispatcher->dispatch(
                 "download_{$nodes[0]->getResourceType()->getName()}",
                 'DownloadResource',


### PR DESCRIPTION
Usefull option in download if you wanna keep the folders and architecture while you have only 1 real file.

( needed for Evaluation in order to download copies, => one folder with the student name is needed )
so without this patch actualy, if there is only 1 file in the directory, this download directly the file without the folder.

ex:
hidden directory for Evaluation1
---- copy_1_Paul_Pale
        ------ mydrop.txt

=> download result is 
only mydrop.txt

what is expected is the same file  structure that in claroline.
