### PR TITLE
Improve breadcrumb macro

### DIFF
--- a/Resources/views/macros.html.twig
+++ b/Resources/views/macros.html.twig
@@ -48,12 +48,10 @@
     {% spaceless %}
     <ul class="breadcrumb">
         {% for element in elements %}
-            <li{% if element['href'] == "" %} class="active"{% endif %}>
-                {% if element['href'] != "" %}
+            <li{% if loop.last %} class="active"{% endif %}>
+                {% if not loop.last %}
                     <a href="{{ element['href'] }}">{% if element['icon'] is defined %}<i class="{{ element['icon'] }}"></i> {% endif %}{{ element['name'] }}</a>
-                {% else %}
-                    {{ element['name'] }}
-                {% endif %}
+                {% else %}<span>{{ element['name'] }}</span>{% endif %}
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
Changed breadcrumb macro so that the last element of the collection is always the active one:

- no need for `href: ''` everywhere; just omit the attribute if it's not needed
- easier to set a base breadcrumb and extend it later:
  ```Twig
{# base template #}

{% set baseBreadcrumbs = [...] %}


{# child template #}
   
{% block breadcrumb %}
        {{
            macros.breadcrumbs(baseBreadcrumbs|merge([{
                'name': 'foo'|trans({}, 'bar')
            }]))
        }}
{% endblock %}   
  ```