### PR TITLE
Upgrade Angular JS to 1.3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -59,7 +59,7 @@
         "johngrogg/ics-parser": "dev-master",
         "gregwar/captcha-bundle": "1.0.12",
         "knplabs/knp-menu-bundle": "2.0.0",
-        "innova/angular-js-bundle": "1.0.2",
+        "innova/angular-js-bundle": "2.0.0",
         "cocur/slugify": "~0.8"
     },
     "require-dev": {


### PR DESCRIPTION
innova/angular-js-bundle 2.0.0 now contains AngularJS 1.3.8.