### PR TITLE
Add additional installer to add portfolio plugin in plugin table

### DIFF
--- a/Library/Installation/AdditionalInstaller.php
+++ b/Library/Installation/AdditionalInstaller.php
@@ -190,6 +190,10 @@ class AdditionalInstaller extends BaseInstaller
                 $updater = new Updater\Updater040801($this->container);
                 $updater->setLogger($this->logger);
                 $updater->postUpdate();
+            case version_compare($currentVersion, '4.8.4', '<'):
+                $updater = new Updater\Updater040804($this->container);
+                $updater->setLogger($this->logger);
+                $updater->postUpdate();
         }
     }
 

--- a/Library/Installation/Updater/Updater040804.php
+++ b/Library/Installation/Updater/Updater040804.php
@@ -1,0 +1,51 @@
+<?php
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Library\Installation\Updater;
+
+use Claroline\CoreBundle\Entity\Plugin;
+use Claroline\CoreBundle\Entity\Tool\OrderedTool;
+use Claroline\InstallationBundle\Updater\Updater;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class Updater040804 extends Updater
+{
+    private $container;
+
+    /** @var \Claroline\CoreBundle\Persistence\ObjectManager */
+    private $om;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+        $this->om = $container->get('claroline.persistence.object_manager');
+    }
+
+    public function postUpdate()
+    {
+        $installedBundles = $this->container->getParameter('kernel.bundles');
+
+        if (isset($installedBundles['IcapPortfolioBundle'])) {
+
+            $icapPortfolioPlugin = $this->om->getRepository('ClarolineCoreBundle:Plugin')->findOneByBundleFQCN($installedBundles['IcapPortfolioBundle']);
+
+            if (null === $icapPortfolioPlugin) {
+                $this->log('    Creation of Portfolio plugin in database.');
+
+                $icapPortfolioPlugin = new Plugin();
+                $icapPortfolioPlugin->setVendorName('Icap');
+                $icapPortfolioPlugin->setBundleName('PortfolioBundle');
+                $icapPortfolioPlugin->setHasOptions(false);
+                $this->om->persist($icapPortfolioPlugin);
+                $this->om->flush();
+            }
+        }
+    }
+}


### PR DESCRIPTION
As before the IcapPortfolioBundle was created as a core features it was specified as `claroline-core` in its config.yml file.
Now as it's a plugin on its own we need to add him in the plugin table as there is no mechanism for such case.