### PR TITLE
Dispatch an event on activity evaluation

### DIFF
--- a/Controller/ActivityController.php
+++ b/Controller/ActivityController.php
@@ -356,25 +356,11 @@ class ActivityController
         ActivityParameters $params
     )
     {
-        $evaluation = $this->activityManager
-            ->getEvaluationByUserAndActivityParams($currentUser, $params);
+        $evaluation =
+            $this->activityManager->getEvaluationByUserAndActivityParams($currentUser, $params) ?:
+            $this->activityManager->createBlankEvaluation($currentUser, $params);
         $pastEvals = $this->activityManager
             ->getPastEvaluationsByUserAndActivityParams($currentUser, $params);
-
-        if (is_null($evaluation)) {
-            $evaluationType = $params->getEvaluationType();
-            $status = ($evaluationType === 'automatic') ?
-                'not_attempted' :
-                null;
-
-            $evaluation = $this->activityManager->createEvaluation(
-                $currentUser,
-                $params,
-                null,
-                null,
-                $status
-            );
-        }
         $ruleScore = null;
         $isResultVisible = false;
 

--- a/Controller/WorkspaceAnalyticsController.php
+++ b/Controller/WorkspaceAnalyticsController.php
@@ -11,6 +11,7 @@
 
 namespace Claroline\CoreBundle\Controller;
 
+use Claroline\CoreBundle\Entity\Activity\AbstractEvaluation;
 use Claroline\CoreBundle\Entity\Activity\ActivityParameters;
 use Claroline\CoreBundle\Entity\Resource\Activity;
 use Claroline\CoreBundle\Entity\User;
@@ -166,9 +167,9 @@ class WorkspaceAnalyticsController extends Controller
     )
     {
         if (!$this->securityContext->isGranted('analytics', $workspace)) {
-
             throw new AccessDeniedException();
         }
+
         $roleNames = $currentUser->getRoles();
         $isWorkspaceManager = $this->isWorkspaceManager($workspace, $roleNames);
 
@@ -240,23 +241,12 @@ class WorkspaceAnalyticsController extends Controller
                 $evaluationType = $params->getEvaluationType();
 
                 if (!isset($evaluationsAssoc[$activity->getId()])) {
-                    $status = ($evaluationType === 'automatic') ?
-                        'not_attempted' :
-                        null;
-
-                    $evaluation = $this->activityManager->createEvaluation(
-                        $currentUser,
-                        $params,
-                        null,
-                        null,
-                        $status
-                    );
-                    $evaluationsAssoc[$activity->getId()] = $evaluation;
+                    $evaluationsAssoc[$activity->getId()] = $this->activityManager
+                        ->createBlankEvaluation($currentUser, $params);
                 }
 
-                if ($evaluationType === 'automatic' &&
-                    count($params->getRules()) > 0) {
-
+                if ($evaluationType === AbstractEvaluation::TYPE_AUTOMATIC
+                    && count($params->getRules()) > 0) {
                     $rule = $params->getRules()->first();
                     $isResultVisible = $rule->getIsResultVisible();
 
@@ -276,9 +266,10 @@ class WorkspaceAnalyticsController extends Controller
                     }
                 }
 
-                if ($evaluationsAssoc[$activity->getId()]->getStatus() === 'completed' ||
-                    $evaluationsAssoc[$activity->getId()]->getStatus() === 'passed') {
+                $status = $evaluationsAssoc[$activity->getId()]->getStatus();
 
+                if ($status === AbstractEvaluation::STATUS_COMPLETED
+                    || $status === AbstractEvaluation::STATUS_PASSED) {
                     $nbSuccess++;
                 }
             }
@@ -356,9 +347,8 @@ class WorkspaceAnalyticsController extends Controller
         $ruleScore = null;
         $isResultVisible = false;
 
-        if ($activityParameters->getEvaluationType() === 'automatic' &&
-            count($activityParameters->getRules()) > 0) {
-
+        if ($activityParameters->getEvaluationType() === AbstractEvaluation::TYPE_AUTOMATIC
+            && count($activityParameters->getRules()) > 0) {
             $rule = $activityParameters->getRules()->first();
             $score = $rule->getResult();
             $scoreMax = $rule->getResultMax();
@@ -423,9 +413,9 @@ class WorkspaceAnalyticsController extends Controller
         $isWorkspaceManager = $this->isWorkspaceManager($workspace, $roleNames);
 
         if (!$isWorkspaceManager) {
-
             throw new AccessDeniedException();
         }
+
         $resourceNode = $activity->getResourceNode();
         $activityParams = $activity->getParameters();
         $roles = $this->roleManager
@@ -437,6 +427,7 @@ class WorkspaceAnalyticsController extends Controller
         foreach ($usersPager as $user) {
             $users[] = $user;
         }
+
         $allEvaluations = $this->activityManager
             ->getEvaluationsByUsersAndActivityParams($users, $activityParams);
         $evaluations = array();
@@ -449,26 +440,15 @@ class WorkspaceAnalyticsController extends Controller
         $nbSuccess = 0;
 
         foreach ($users as $user) {
-
             if (!isset($evaluations[$user->getId()])) {
-                $evaluationType = $activityParams->getEvaluationType();
-                $status = ($evaluationType === 'automatic') ?
-                    'not_attempted' :
-                    null;
-
-                $evaluation = $this->activityManager->createEvaluation(
-                    $user,
-                    $activityParams,
-                    null,
-                    null,
-                    $status
-                );
-                $evaluations[$user->getId()] = $evaluation;
+                $evaluations[$user->getId()] = $this->activityManager
+                    ->createBlankEvaluation($user, $activityParams);
             }
 
-            if ($evaluations[$user->getId()]->getStatus() === 'completed' ||
-                $evaluations[$user->getId()]->getStatus() === 'passed') {
+            $status = $evaluations[$user->getId()]->getStatus();
 
+            if ($status === AbstractEvaluation::STATUS_COMPLETED
+                || $status === AbstractEvaluation::STATUS_PASSED) {
                 $nbSuccess++;
             }
         }
@@ -478,9 +458,8 @@ class WorkspaceAnalyticsController extends Controller
 
         $ruleScore = null;
 
-        if ($activityParams->getEvaluationType() === 'automatic' &&
-            count($activityParams->getRules()) > 0) {
-
+        if ($activityParams->getEvaluationType() === AbstractEvaluation::TYPE_AUTOMATIC
+            && count($activityParams->getRules()) > 0) {
             $rule = $activityParams->getRules()->first();
             $score = $rule->getResult();
             $scoreMax = $rule->getResultMax();

--- a/Entity/Activity/AbstractEvaluation.php
+++ b/Entity/Activity/AbstractEvaluation.php
@@ -1,0 +1,207 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Entity\Activity;
+
+use Claroline\CoreBundle\Entity\Log\Log;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\MappedSuperclass
+ */
+class AbstractEvaluation
+{
+    const TYPE_AUTOMATIC = 'automatic';
+    const TYPE_MANUAL = 'manual';
+
+    const STATUS_PASSED = 'passed';
+    const STATUS_FAILED = 'failed';
+    const STATUS_COMPLETED = 'completed';
+    const STATUS_INCOMPLETE = 'incomplete';
+    const STATUS_NOT_ATTEMPTED = 'not_attempted';
+    const STATUS_UNKNOWN = 'unknown';
+
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="integer")
+     * @ORM\GeneratedValue(strategy="AUTO")
+     */
+    protected $id;
+
+    /**
+     * @ORM\Column(name="evaluation_type", nullable=true)
+     */
+    protected $type;
+
+    /**
+     * @ORM\Column(name="evaluation_status", nullable=true)
+     */
+    protected $status;
+
+    /**
+     * @ORM\Column(type="integer", nullable=true)
+     */
+    protected $duration;
+
+    /**
+     * @ORM\Column(nullable=true)
+     */
+    protected $score;
+
+    /**
+     * @ORM\Column(name="score_num", type="integer", nullable=true)
+     */
+    protected $numScore;
+
+    /**
+     * @ORM\Column(name="score_min", type="integer", nullable=true)
+     */
+    protected $scoreMin;
+
+    /**
+     * @ORM\Column(name="score_max", type="integer", nullable=true)
+     */
+    protected $scoreMax;
+
+    /**
+     * @ORM\Column(name="evaluation_comment", nullable=true)
+     */
+    protected $comment;
+
+    /**
+     * @ORM\Column(type="json_array", nullable=true)
+     */
+    protected $details;
+
+    /**
+     * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\Log\Log")
+     * @ORM\JoinColumn(onDelete="SET NULL")
+     */
+    protected $log;
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    public function setType($type)
+    {
+        $this->type = $type;
+    }
+
+    public function getStatus()
+    {
+        return $this->status;
+    }
+
+    public function setStatus($status)
+    {
+        $this->status = $status;
+    }
+
+    public function getDuration()
+    {
+        return $this->duration;
+    }
+
+    public function setDuration($duration)
+    {
+        $this->duration = $duration;
+    }
+
+    public function getScore()
+    {
+        return $this->score;
+    }
+
+    public function setScore($score)
+    {
+        $this->score = $score;
+    }
+
+    public function getNumScore()
+    {
+        return $this->numScore;
+    }
+
+    public function setNumScore($numScore)
+    {
+        $this->numScore = $numScore;
+    }
+
+    public function getScoreMin()
+    {
+        return $this->scoreMin;
+    }
+
+    public function setScoreMin($scoreMin)
+    {
+        $this->scoreMin = $scoreMin;
+    }
+
+    public function getScoreMax()
+    {
+        return $this->scoreMax;
+    }
+
+    public function setScoreMax($scoreMax)
+    {
+        $this->scoreMax = $scoreMax;
+    }
+
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+    }
+
+    public function getDetails()
+    {
+        return $this->details;
+    }
+
+    public function setDetails($details)
+    {
+        $this->details = $details;
+    }
+
+    public function getLog()
+    {
+        return $this->log;
+    }
+
+    public function setLog(Log $log)
+    {
+        $this->log = $log;
+    }
+
+    public function isTerminated()
+    {
+        return $this->status !== self::STATUS_NOT_ATTEMPTED
+            && $this->status !== self::STATUS_INCOMPLETE
+            && $this->status !== self::STATUS_UNKNOWN;
+    }
+
+    public function isSuccessful()
+    {
+        return $this->status === self::STATUS_PASSED
+            || $this->status === self::STATUS_COMPLETED;
+    }
+}

--- a/Entity/Activity/Evaluation.php
+++ b/Entity/Activity/Evaluation.php
@@ -11,6 +11,7 @@
 
 namespace Claroline\CoreBundle\Entity\Activity;
 
+use Claroline\CoreBundle\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -25,27 +26,16 @@ use Doctrine\ORM\Mapping as ORM;
  *     }
  * )
  */
-class Evaluation
+class Evaluation extends AbstractEvaluation
 {
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    protected $id;
-
-    /**
-     * @ORM\ManyToOne(
-     *     targetEntity="Claroline\CoreBundle\Entity\User"
-     * )
-     * @ORM\JoinColumn(name="user_id", onDelete="CASCADE", nullable=false)
+     * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\User")
+     * @ORM\JoinColumn(onDelete="CASCADE", nullable=false)
      */
     protected $user;
 
     /**
-     * @ORM\ManyToOne(
-     *     targetEntity="Claroline\CoreBundle\Entity\Activity\ActivityParameters"
-     * )
+     * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\Activity\ActivityParameters")
      * @ORM\JoinColumn(name="activity_parameters_id", onDelete="CASCADE", nullable=false)
      */
     protected $activityParameters;
@@ -54,51 +44,6 @@ class Evaluation
      * @ORM\Column(name="lastest_evaluation_date", type="datetime", nullable=true)
      */
     protected $date;
-
-    /**
-     * @ORM\Column(name="evaluation_type", nullable=true)
-     */
-    protected $type;
-
-    /**
-     * @ORM\Column(name="evaluation_status", nullable=true)
-     */
-    protected $status;
-
-    /**
-     * @ORM\Column(type="integer", nullable=true)
-     */
-    protected $duration;
-
-    /**
-     * @ORM\Column(nullable=true)
-     */
-    protected $score;
-
-    /**
-     * @ORM\Column(name="score_num", type="integer", nullable=true)
-     */
-    protected $numScore;
-
-    /**
-     * @ORM\Column(name="score_min", type="integer", nullable=true)
-     */
-    protected $scoreMin;
-
-    /**
-     * @ORM\Column(name="score_max", type="integer", nullable=true)
-     */
-    protected $scoreMax;
-
-    /**
-     * @ORM\Column(name="evaluation_comment", nullable=true)
-     */
-    protected $comment;
-
-    /**
-     * @ORM\Column(type="json_array", nullable=true)
-     */
-    protected $details;
 
     /**
      * @ORM\Column(name="total_duration", type="integer", nullable=true)
@@ -110,30 +55,12 @@ class Evaluation
      */
     protected $attemptsCount;
 
-    /**
-     * @ORM\ManyToOne(
-     *     targetEntity="Claroline\CoreBundle\Entity\Log\Log"
-     * )
-     * @ORM\JoinColumn(name="log_id", onDelete="SET NULL", nullable=true)
-     */
-    protected $log;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
-
     public function getUser()
     {
         return $this->user;
     }
 
-    public function setUser($user)
+    public function setUser(User $user)
     {
         $this->user = $user;
     }
@@ -158,96 +85,6 @@ class Evaluation
         $this->date = $date;
     }
 
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    public function setType($type)
-    {
-        $this->type = $type;
-    }
-
-    public function getStatus()
-    {
-        return $this->status;
-    }
-
-    public function setStatus($status)
-    {
-        $this->status = $status;
-    }
-
-    public function getDuration()
-    {
-        return $this->duration;
-    }
-
-    public function setDuration($duration)
-    {
-        $this->duration = $duration;
-    }
-
-    public function getScore()
-    {
-        return $this->score;
-    }
-
-    public function setScore($score)
-    {
-        $this->score = $score;
-    }
-
-    public function getNumScore()
-    {
-        return $this->numScore;
-    }
-
-    public function setNumScore($numScore)
-    {
-        $this->numScore = $numScore;
-    }
-
-    public function getScoreMin()
-    {
-        return $this->scoreMin;
-    }
-
-    public function setScoreMin($scoreMin)
-    {
-        $this->scoreMin = $scoreMin;
-    }
-
-    public function getScoreMax()
-    {
-        return $this->scoreMax;
-    }
-
-    public function setScoreMax($scoreMax)
-    {
-        $this->scoreMax = $scoreMax;
-    }
-
-    public function getComment()
-    {
-        return $this->comment;
-    }
-
-    public function setComment($comment)
-    {
-        $this->comment = $comment;
-    }
-
-    public function getDetails()
-    {
-        return $this->details;
-    }
-
-    public function setDetails($details)
-    {
-        $this->details = $details;
-    }
-
     public function getAttemptsDuration()
     {
         return $this->attemptsDuration;
@@ -266,15 +103,5 @@ class Evaluation
     public function setAttemptsCount($attemptsCount)
     {
         $this->attemptsCount = $attemptsCount;
-    }
-
-    public function getLog()
-    {
-        return $this->log;
-    }
-
-    public function setLog($log)
-    {
-        $this->log = $log;
     }
 }

--- a/Entity/Activity/PastEvaluation.php
+++ b/Entity/Activity/PastEvaluation.php
@@ -11,34 +11,24 @@
 
 namespace Claroline\CoreBundle\Entity\Activity;
 
+use Claroline\CoreBundle\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
  * @ORM\Entity(repositoryClass="Claroline\CoreBundle\Repository\Activity\PastEvaluationRepository")
  * @ORM\Table(name="claro_activity_past_evaluation")
  */
-class PastEvaluation
+class PastEvaluation extends AbstractEvaluation
 {
     /**
-     * @ORM\Id
-     * @ORM\Column(type="integer")
-     * @ORM\GeneratedValue(strategy="AUTO")
-     */
-    protected $id;
-
-    /**
-     * @ORM\ManyToOne(
-     *     targetEntity="Claroline\CoreBundle\Entity\User"
-     * )
-     * @ORM\JoinColumn(name="user_id", onDelete="SET NULL", nullable=true)
+     * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\User")
+     * @ORM\JoinColumn(onDelete="SET NULL")
      */
     protected $user;
 
     /**
-     * @ORM\ManyToOne(
-     *     targetEntity="Claroline\CoreBundle\Entity\Activity\ActivityParameters"
-     * )
-     * @ORM\JoinColumn(name="activity_parameters_id", onDelete="SET NULL", nullable=true)
+     * @ORM\ManyToOne(targetEntity="Claroline\CoreBundle\Entity\Activity\ActivityParameters")
+     * @ORM\JoinColumn(name="activity_parameters_id", onDelete="SET NULL")
      */
     protected $activityParameters;
 
@@ -47,75 +37,12 @@ class PastEvaluation
      */
     protected $date;
 
-    /**
-     * @ORM\Column(name="evaluation_type", nullable=true)
-     */
-    protected $type;
-
-    /**
-     * @ORM\Column(name="evaluation_status", nullable=true)
-     */
-    protected $status;
-
-    /**
-     * @ORM\Column(type="integer", nullable=true)
-     */
-    protected $duration;
-
-    /**
-     * @ORM\Column(nullable=true)
-     */
-    protected $score;
-
-    /**
-     * @ORM\Column(name="score_num", type="integer", nullable=true)
-     */
-    protected $numScore;
-
-    /**
-     * @ORM\Column(name="score_min", type="integer", nullable=true)
-     */
-    protected $scoreMin;
-
-    /**
-     * @ORM\Column(name="score_max", type="integer", nullable=true)
-     */
-    protected $scoreMax;
-
-    /**
-     * @ORM\Column(name="evaluation_comment", nullable=true)
-     */
-    protected $comment;
-
-    /**
-     * @ORM\Column(type="json_array", nullable=true)
-     */
-    protected $details;
-
-    /**
-     * @ORM\ManyToOne(
-     *     targetEntity="Claroline\CoreBundle\Entity\Log\Log"
-     * )
-     * @ORM\JoinColumn(name="log_id", onDelete="SET NULL", nullable=true)
-     */
-    protected $log;
-
-    public function getId()
-    {
-        return $this->id;
-    }
-
-    public function setId($id)
-    {
-        $this->id = $id;
-    }
-
     public function getUser()
     {
         return $this->user;
     }
 
-    public function setUser($user)
+    public function setUser(User $user)
     {
         $this->user = $user;
     }
@@ -138,105 +65,5 @@ class PastEvaluation
     public function setDate($date)
     {
         $this->date = $date;
-    }
-
-    public function getType()
-    {
-        return $this->type;
-    }
-
-    public function setType($type)
-    {
-        $this->type = $type;
-    }
-
-    public function getStatus()
-    {
-        return $this->status;
-    }
-
-    public function setStatus($status)
-    {
-        $this->status = $status;
-    }
-
-    public function getDuration()
-    {
-        return $this->duration;
-    }
-
-    public function setDuration($duration)
-    {
-        $this->duration = $duration;
-    }
-
-    public function getScore()
-    {
-        return $this->score;
-    }
-
-    public function setScore($score)
-    {
-        $this->score = $score;
-    }
-
-    public function getNumScore()
-    {
-        return $this->numScore;
-    }
-
-    public function setNumScore($numScore)
-    {
-        $this->numScore = $numScore;
-    }
-
-    public function getScoreMin()
-    {
-        return $this->scoreMin;
-    }
-
-    public function setScoreMin($scoreMin)
-    {
-        $this->scoreMin = $scoreMin;
-    }
-
-    public function getScoreMax()
-    {
-        return $this->scoreMax;
-    }
-
-    public function setScoreMax($scoreMax)
-    {
-        $this->scoreMax = $scoreMax;
-    }
-
-    public function getComment()
-    {
-        return $this->comment;
-    }
-
-    public function setComment($comment)
-    {
-        $this->comment = $comment;
-    }
-
-    public function getDetails()
-    {
-        return $this->details;
-    }
-
-    public function setDetails($details)
-    {
-        $this->details = $details;
-    }
-
-    public function getLog()
-    {
-        return $this->log;
-    }
-
-    public function setLog($log)
-    {
-        $this->log = $log;
     }
 }

--- a/Event/ActivityEvaluationEvent.php
+++ b/Event/ActivityEvaluationEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Event;
+
+use Claroline\CoreBundle\Entity\Activity\Evaluation;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event dispatched when an activity evaluation is created or updated.
+ */
+class ActivityEvaluationEvent extends Event
+{
+    private $evaluation;
+
+    public function __construct(Evaluation $evaluation)
+    {
+        $this->evaluation = $evaluation;
+    }
+
+    public function getEvaluation()
+    {
+        return $this->evaluation;
+    }
+}

--- a/Listener/Resource/ActivityListener.php
+++ b/Listener/Resource/ActivityListener.php
@@ -165,27 +165,9 @@ class ActivityListener
         $activity = $event->getResource();
         $params = $activity->getParameters();
         $user = $this->securityContext->getToken()->getUser();
-        $evaluation = $this->activityManager
-            ->getEvaluationByUserAndActivityParams($user, $params);
-
-        if (is_null($evaluation)) {
-            $evaluationType = $params->getEvaluationType();
-            $status = ($evaluationType === 'automatic') ?
-                'not_attempted' :
-                null;
-            $nbAttempts = ($evaluationType === 'automatic') ?
-                0 :
-                null;
-
-            $evaluation = $this->activityManager->createEvaluation(
-                $user,
-                $params,
-                $evaluationType,
-                null,
-                $status,
-                $nbAttempts
-            );
-        }
+        $evaluation =
+            $this->activityManager->getEvaluationByUserAndActivityParams($user, $params) ?:
+            $this->activityManager->createBlankEvaluation($user, $params);
 
         $content = $this->templating->render(
             'ClarolineCoreBundle:Activity:index.html.twig',


### PR DESCRIPTION
Makes the activity manager dispatch an `activity_evaluation` event when an evaluation is terminated. 

Additional cleanup:

- duplicate code of `Evaluation` and `PastEvaluation` entities is moved to a mapped super class
- literal strings are replaced by class constants for evaluation statuses
