### PR TITLE
Set symfony to 2.7 branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": ">=5.4.1",
         "ext-mcrypt": "*",
-        "symfony/symfony": "2.7.0-BETA1",
+        "symfony/symfony": "~2.7",
         "doctrine/dbal": "~2.4",
         "symfony/assetic-bundle": "~2.4",
         "symfony/swiftmailer-bundle": "~2.3",


### PR DESCRIPTION
Workspace creation (at least) is currently impossible due to symfony/symfony#14393. That bug is fixed on the 2.7 branch. There's no point in sticking to a beta tag IMO.