### PR TITLE
Remove angularjs-bundle from the core

### DIFF
--- a/ClarolineCoreBundle.php
+++ b/ClarolineCoreBundle.php
@@ -71,7 +71,6 @@ class ClarolineCoreBundle extends InstallableBundle implements AutoConfigurableI
             'Claroline\MigrationBundle\ClarolineMigrationBundle',
             'Claroline\Bundle\FrontEndBundle\FrontEndBundle',
             'JMS\SerializerBundle\JMSSerializerBundle',
-            'Innova\AngularJSBundle\InnovaAngularJSBundle',
         );
         // simple container configuration, same for every environment
         $simpleConfigs = array(

--- a/composer.json
+++ b/composer.json
@@ -58,8 +58,7 @@
         "johngrogg/ics-parser": "dev-master",
         "gregwar/captcha-bundle": "1.0.12",
         "knplabs/knp-menu-bundle": "2.0.0",
-        "cocur/slugify": "~1.0",
-        "innova/angular-js-bundle": "~5.0"
+        "cocur/slugify": "~1.0"
     },
     "require-dev": {
         "mockery/mockery": "dev-master@dev",


### PR DESCRIPTION
If a bundle need angularJs he should require it and register it in its bundle class.