### PR TITLE
Redesign login page

### DIFF
--- a/Controller/AuthenticationController.php
+++ b/Controller/AuthenticationController.php
@@ -336,6 +336,11 @@ class AuthenticationController
     {
         $event = $this->dispatcher->dispatch('render_external_authentication_button', 'RenderAuthenticationButton');
 
-        return new Response($event->getContent());
+        $eventContent = $event->getContent();
+        if (!empty($eventContent)) {
+            $eventContent = '<div class="external_authentication"><hr>' . $eventContent . '</div>';
+        }
+
+        return new Response($eventContent);
     }
 }

--- a/Resources/views/Authentication/login.html.twig
+++ b/Resources/views/Authentication/login.html.twig
@@ -9,48 +9,53 @@ same message when authentication has failed (no precise validation errors).
 
 {% block content %}
     {{ macros.flashBox() }}
-    <div class="col-md-offset-4 col-md-4">
-        {% if error %}
-            <div class="alert alert-danger">
-                <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                {{ 'login_failure'|trans({}, 'platform') }}
-            </div>
-        {% endif %}
-        {% if is_expired %}
-            <div class="alert alert-danger">
-                <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
-                {{ 'closed_account'|trans({}, 'platform') }}
-            </div>
-        {% endif %}
-        <div class='panel panel-default'>
-            <div class="panel-heading">
-                <h3 class="panel-title">{{ 'login' | trans({}, "platform")}}</h3>
-            </div>
+    <div class="row login_form_container" style="background-color: whitesmoke">
+        <div class="col-md-offset-5 col-md-2">
             <form role="form" action="{{ path('claro_security_login_check') }}" method="post">
-                <div class="panel-body">
-                    <div class="form-group">
-                        <label for="username">{{ 'username_or_email'|trans({}, 'platform') }}</label>
+                <h2>{{ 'login' | trans({}, "platform")}}</h2>
+                {% if error %}
+                    <div class="alert alert-danger">
+                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                        {{ 'login_failure'|trans({}, 'platform') }}
+                    </div>
+                {% endif %}
+                {% if is_expired %}
+                    <div class="alert alert-danger">
+                        <button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>
+                        {{ 'closed_account'|trans({}, 'platform') }}
+                    </div>
+                {% endif %}
+                <div class="form-group">
+                    <label for="username">{{ 'username_or_email'|trans({}, 'platform') }}</label>
+                    <div class="input-group">
+                        <span class="input-group-addon">
+                            <i class="fa fa-user" title="{{ 'username_or_email'|trans({}, 'platform') }}"></i>
+                        </span>
                         <input type="text" class="form-control" id="username" name="_username" placeholder="{{ 'username_or_email' | trans({}, 'platform') }}" tabindex="1" autofocus>
                     </div>
-                    <div class="form-group">
-                        <label for="password">
-                            {{ 'password'|trans({}, 'platform') }}
-                            <small>
-                                <a href ="{{ path('claro_security_forgot_password')}}" tabindex="4">({{ 'forgot_password'|trans({}, 'platform') }})</a>
-                            </small>
-                        </label>
+                </div>
+                <div class="form-group">
+                    <label for="password">
+                        {{ 'password'|trans({}, 'platform') }}
+                    </label>
+                    <div class="input-group">
+                        <span class="input-group-addon">
+                            <i class="fa fa-lock" title="{{ 'password'|trans({}, 'platform') }}"></i>
+                        </span>
                         <input type="password" class="form-control" id="password" name="_password" placeholder="{{ 'password'|trans({}, 'platform') }}" tabindex="2">
                     </div>
-                    <input type="checkbox" id="remember_me" name="_remember_me" />
-                    <label for="remember_me">{{ 'keep_me_logged_in'|trans({}, 'platform') }}</label>
                 </div>
-                <div class="panel-footer">
-                    <button type="submit" class="btn btn-primary" tabindex="3">{{ 'login'|trans({}, 'platform') }}</button>
-                    {% if selfRegistrationAllowed == true %}
-                        <a href="{{ path('claro_registration_user_registration_form', {}) }}" class="btn btn-default" tabindex="3">{{ 'register'|trans({}, 'platform') }}</a>
-                    {% endif %}
-                    {{ render(controller('ClarolineCoreBundle:Authentication:renderExternalAuthenticatonButton', {})) }}
+                <div class="checkbox">
+                    <label>
+                      <input type="checkbox" id="remember_me" name="_remember_me" /> {{ 'keep_me_logged_in'|trans({}, 'platform') }}
+                    </label>
                 </div>
+                <p>
+                    <a href ="{{ path('claro_security_forgot_password')}}" tabindex="4">{{ 'forgot_password'|trans({}, 'platform') }}</a>
+                </p>
+
+                <button type="submit" class="btn btn-success btn-block" tabindex="3">{{ 'login'|trans({}, 'platform') }}</button>
+                {{ render(controller('ClarolineCoreBundle:Authentication:renderExternalAuthenticatonButton', {})) }}
             </form>
         </div>
     </div>

--- a/Resources/views/less/layout.less
+++ b/Resources/views/less/layout.less
@@ -1553,14 +1553,25 @@ body.mce-fullscreen .modal.fullscreen {
     white-space: nowrap;
 }
 
+.login_form_container {
+    h2 {
+        margin-bottom: 30px;
+    }
+    form {
+        padding-bottom: 20px;
+        .external_authentication {
+            hr {
+                border-top-color: #cccccc;
+            }
+        }
+    }
+}
+
 /**********************/
 /**    Facebook      **/
 /**********************/
 
 .facebook-connect {
-    margin-left: 5px;
-    overflow: hidden;
-    position: absolute;
     .fb-login-button {
         opacity: 0;
         position: absolute;


### PR DESCRIPTION
I propose to you a redesign of the login page.
Of course it's just a proposition that needs approval before being merged.
See the new page with the facebook connection button:

![login-page](https://cloud.githubusercontent.com/assets/792787/7748284/5cc7a4ce-ffc3-11e4-9db2-a34210853e90.png)

And without the facebook connection button:
![login-page-facebook](https://cloud.githubusercontent.com/assets/792787/7748285/611e130a-ffc3-11e4-9282-cefcb0cdb57e.png)

A PR for the FacebookBundle is on its way for a little redesign of the button.