### PR TITLE
Refacto resourcepicker form field with html template

### DIFF
--- a/Form/Field/ButtonGroupSelectType.php
+++ b/Form/Field/ButtonGroupSelectType.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Claroline\CoreBundle\Form;
+namespace Claroline\CoreBundle\Form\Field;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use JMS\DiExtraBundle\Annotation as DI;
 
 /**
- * @DI\Service("claroline.form.twolevelselect")
- * @DI\FormType(alias = "twolevelselect")
+ * @DI\Service("claroline.form.buttongroupselect")
+ * @DI\FormType(alias = "buttongroupselect")
  */
-class TwoLevelSelectType extends AbstractType
+class ButtonGroupSelectType extends AbstractType
 {
     public function getParent()
     {
@@ -28,10 +28,10 @@ class TwoLevelSelectType extends AbstractType
 
     public function getName()
     {
-        return 'twolevelselect';
+        return 'buttongroupselect';
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
         $resolver
         ->setDefaults(

--- a/Form/Field/DatePickerType.php
+++ b/Form/Field/DatePickerType.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Claroline\CoreBundle\Form;
+namespace Claroline\CoreBundle\Form\Field;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;

--- a/Form/Field/DateRangeType.php
+++ b/Form/Field/DateRangeType.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Claroline\CoreBundle\Form;
+namespace Claroline\CoreBundle\Form\Field;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;

--- a/Form/Field/DateTimePickerType.php
+++ b/Form/Field/DateTimePickerType.php
@@ -7,7 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-namespace Claroline\CoreBundle\Form;
+namespace Claroline\CoreBundle\Form\Field;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;

--- a/Form/Field/ResourcePickerType.php
+++ b/Form/Field/ResourcePickerType.php
@@ -20,7 +20,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\Options;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Form\FormBuilderInterface;
 
 /**
@@ -60,16 +60,13 @@ class ResourcePickerType extends TextType
         $builder->addModelTransformer($this->transformer);
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array('label' => 'resource', 'attr' => $this->defaultAttributes));
-        $resolver->setNormalizers(
-            array(
-                'attr' => function (Options $options, $value) {
-                    return array_merge($this->defaultAttributes, $value);
-                }
-            )
-        );
+        $resolver
+            ->setNormalizer('attr', function (Options $options, $value) {
+                return array_merge($this->defaultAttributes, $value);
+            });
     }
 
     public function finishView(FormView $view, FormInterface $form, array $options)

--- a/Form/Field/ResourcePickerType.php
+++ b/Form/Field/ResourcePickerType.php
@@ -60,9 +60,25 @@ class ResourcePickerType extends TextType
         $builder->addModelTransformer($this->transformer);
     }
 
+    public function buildView(FormView $view, FormInterface $form, array $options)
+    {
+        $view->vars['display_view_button'] = $options['display_view_button'];
+        $view->vars['display_browse_button'] = $options['display_browse_button'];
+        $view->vars['display_download_button'] = $options['display_download_button'];
+    }
+
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array('label' => 'resource', 'attr' => $this->defaultAttributes));
+        $resolver->setDefaults(
+            array(
+                'label' => 'resource',
+                'attr' => $this->defaultAttributes,
+                'display_view_button' => true,
+                'display_browse_button' => true,
+                'display_download_button' => true
+            )
+        );
+
         $resolver
             ->setNormalizer('attr', function (Options $options, $value) {
                 return array_merge($this->defaultAttributes, $value);

--- a/Form/Field/SimpleAutoCompleteType.php
+++ b/Form/Field/SimpleAutoCompleteType.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Claroline\CoreBundle\Form;
+namespace Claroline\CoreBundle\Form\Field;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormInterface;

--- a/Form/Field/TwoLevelSelectType.php
+++ b/Form/Field/TwoLevelSelectType.php
@@ -9,17 +9,17 @@
  * file that was distributed with this source code.
  */
 
-namespace Claroline\CoreBundle\Form;
+namespace Claroline\CoreBundle\Form\Field;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use JMS\DiExtraBundle\Annotation as DI;
 
 /**
- * @DI\Service("claroline.form.buttongroupselect")
- * @DI\FormType(alias = "buttongroupselect")
+ * @DI\Service("claroline.form.twolevelselect")
+ * @DI\FormType(alias = "twolevelselect")
  */
-class ButtonGroupSelectType extends AbstractType
+class TwoLevelSelectType extends AbstractType
 {
     public function getParent()
     {
@@ -28,10 +28,10 @@ class ButtonGroupSelectType extends AbstractType
 
     public function getName()
     {
-        return 'buttongroupselect';
+        return 'twolevelselect';
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
         ->setDefaults(

--- a/Form/Field/UserPickerType.php
+++ b/Form/Field/UserPickerType.php
@@ -18,8 +18,8 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @DI\Service("claroline.form.user_picker")
@@ -86,7 +86,7 @@ class UserPickerType extends AbstractType
         $view->vars['shown_workspaces'] = $options['shown_workspaces'];
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(
             array(

--- a/Resources/config/suggested/twig.yml
+++ b/Resources/config/suggested/twig.yml
@@ -13,4 +13,5 @@ twig:
             - 'ClarolineCoreBundle:Form:simple_auto_complete.html.twig'
             - 'ClarolineCoreBundle:Form:button_group_select.html.twig'
             - 'ClarolineCoreBundle:Form:user_picker.html.twig'
+            - 'ClarolineCoreBundle:Form:resource_picker.html.twig'
             - 'ClarolineCoreBundle::form_theme.html.twig'

--- a/Resources/public/js/resourceinput.js
+++ b/Resources/public/js/resourceinput.js
@@ -10,6 +10,7 @@
 (function () {
     'use strict';
 
+    window.Claroline.ResourcePicker = {};
     var manager = window.Claroline.ResourceManager;
     var common = window.Claroline.Common;
     var modal = window.Claroline.Modal;
@@ -30,41 +31,58 @@
     };
 
 
-    $(document).ready(function () {
-        initialize();
-        $('body').bind({
-            'ajaxComplete': function () {
-                initialize();
-            },
-            'DOMSubtreeModified': function () {
-                clearTimeout(timeoutId);
-                timeoutId = setTimeout(initialize, 10);
-            }
-        });
-    });
-
     /**
      * Initializes every resource input on the page.
      */
-    function initialize() {
-        $('input.resource-picker:not(.resource-picker-done)').each(function () {
-            var pickerName = 'formResourcePicker';
-            var customParameters = processCustomParameters($(this).data());
+    window.Claroline.ResourcePicker.initialize = function (id) {
+        var pickerName = 'formResourcePicker';
+        var field = $('#' + id);
+        var element = field.next('.input-group');
 
-            var element = createInput(this.parentNode, pickerName, customParameters);
-            var name = $(this).data('name');
+        $('input.form-control', element)
+            .on('focus', function () {
+                activePicker = this.parentNode;
+                openPicker(pickerName, customParameters);
+            });
 
-            if (name) {
-                $('.input-group input', element).val(name);
-            }
+        var inputGroupButton = $('.input-group-btn', element);
 
-            if ($(this).next().hasClass('help-block')) {
-                $(this).next().appendTo(element);
-            }
+        $('button.resource-browse', inputGroupButton)
+            .on('click', function () {
+                activePicker = this.parentNode.parentNode;
+                openPicker(pickerName, customParameters);
+            });
 
-            $(this).addClass('resource-picker-done').addClass('hide');
-            checkView($('.input-group', element));
-        });
+        $('button.resource-download', inputGroupButton)
+            .on('click', function () {
+                activePicker = this.parentNode.parentNode;
+                modal.fromRoute('claro_upload_modal', null, function (element) {
+                    element.on('click', '.resourcePicker', function () {
+                        openPicker(pickerName, customParameters);
+                    })
+                        .on('click', '.filePicker', function () {
+                            $('#file_form_file').click();
+                        })
+                        .on('change', '#file_form_file', function () {
+                            common.uploadfile(this, element, defaultCallback);
+                        });
+                });
+            });
+
+        var customParameters = processCustomParameters(field.data());
+
+        var name = field.data('name');
+
+        if (name) {
+            $('input', element).val(name);
+        }
+
+        if (field.next().hasClass('help-block')) {
+            field.next().appendTo(element);
+        }
+
+        field.addClass('resource-picker-done').addClass('hide');
+        checkView($('.input-group', field));
     };
 
     function processCustomParameters(datas) {
@@ -74,9 +92,6 @@
             'restrictForOwner',
             'isPickerMultiSelectAllowed',
             'isDirectorySelectionAllowed',
-            'displayViewButton',
-            'displayBrowseButton',
-            'displayDownloadButton'
         ];
         var arrayParameterList = [
             'typeBlackList',
@@ -100,81 +115,6 @@
         }
 
         return customParameters;
-    }
-
-    /**
-     * Creates a resource input as child of a dom element
-     */
-    function createInput(parentElement, pickerName, customParameters) {
-        var displayViewButton     = (customParameters && undefined !== customParameters['displayViewButton']) ? customParameters['displayViewButton'] : true;
-        var displayBrowseButton   = (customParameters && undefined !== customParameters['displayBrowseButton']) ? customParameters['displayBrowseButton'] : true;
-        var displayDownloadButton = (customParameters && undefined !== customParameters['displayDownloadButton']) ? customParameters['displayDownloadButton'] : true;
-
-        var buttonBar = common.createElement('span', 'input-group-btn');
-
-        if (displayViewButton) {
-            buttonBar.append(
-                common.createElement('a', 'btn btn-default disabled resource-view')
-                    .append(common.createElement('i', 'fa fa-eye'))
-                    .attr('title', translator.trans('see', {}, 'platform'))
-                    .attr('data-toggle', 'tooltip')
-                    .attr('target', '_blank')
-                    .css('margin', '0')
-            );
-        }
-
-        if (displayBrowseButton) {
-            buttonBar.append(
-                common.createElement('a', 'btn btn-default')
-                    .append(common.createElement('i', 'fa fa-folder-open'))
-                    .attr('title', translator.trans('resources', {}, 'platform'))
-                    .attr('data-toggle', 'tooltip')
-                    .css('margin', '0')
-                    .on('click', function () {
-                        activePicker = this.parentNode.parentNode;
-                        openPicker(pickerName, customParameters);
-                    })
-            );
-        }
-
-        if (displayDownloadButton) {
-            buttonBar.append(
-                common.createElement('a', 'btn btn-default')
-                    .append(common.createElement('i', 'fa fa-file'))
-                    .attr('title', translator.trans('upload', {}, 'platform'))
-                    .attr('data-toggle', 'tooltip')
-                    .css('margin', '0')
-                    .on('click', function () {
-                        activePicker = this.parentNode.parentNode;
-                        modal.fromRoute('claro_upload_modal', null, function (element) {
-                            element.on('click', '.resourcePicker', function () {
-                                openPicker(pickerName, customParameters);
-                            })
-                                .on('click', '.filePicker', function () {
-                                    $('#file_form_file').click();
-                                })
-                                .on('change', '#file_form_file', function () {
-                                    common.uploadfile(this, element, defaultCallback);
-                                });
-                        });
-                    })
-            );
-        }
-
-        return $(parentElement).append(
-            common.createElement('div', 'input-group')
-                .append(
-                    common.createElement('input', 'form-control')
-                        .css('cursor', 'pointer')
-                        .attr('type', 'text')
-                        .attr('placeholder', translator.trans('add_resource', {}, 'platform'))
-                        .on('focus', function () {
-                            activePicker = this.parentNode;
-                            openPicker(pickerName, customParameters);
-                        })
-                )
-                .append(buttonBar)
-        );
     }
 
     /**

--- a/Resources/public/js/resourceinput.js
+++ b/Resources/public/js/resourceinput.js
@@ -82,7 +82,7 @@
         }
 
         field.addClass('resource-picker-done').addClass('hide');
-        checkView($('.input-group', field));
+        checkView(element);
     };
 
     function processCustomParameters(datas) {

--- a/Resources/views/Form/resource_picker.html.twig
+++ b/Resources/views/Form/resource_picker.html.twig
@@ -1,0 +1,12 @@
+{% extends 'ClarolineCoreBundle::form_theme.html.twig' %}
+
+{% block resourcePicker_widget %}
+    {% spaceless %}
+        {{ block('form_widget') }}
+        {% javascripts debug=false filter='jsmin' output='js/claroline/resourceinput.js'
+            'bundles/clarolinecore/js/resourceinput.js'
+        %}
+            <script type="text/javascript" src="{{ asset_url }}"></script>
+        {% endjavascripts %}
+    {% endspaceless %}
+{% endblock %}

--- a/Resources/views/Form/resource_picker.html.twig
+++ b/Resources/views/Form/resource_picker.html.twig
@@ -3,10 +3,47 @@
 {% block resourcePicker_widget %}
     {% spaceless %}
         {{ block('form_widget') }}
+        {% set inputGroupMode = display_view_button or display_browse_button or display_download_button %}
+        {% if inputGroupMode %}
+        <div class="input-group">
+            {% endif %}
+            <input class="form-control" type="text" placeholder="{{ 'add_resource'|trans({}, 'platform') }}" style="cursor: pointer;">
+            {% if inputGroupMode %}
+            <span class="input-group-btn">
+            {% if display_view_button %}
+                <a  class="btn btn-default disabled resource-view" title="Voir" data-toggle="tooltip" target="_blank" href="" style="margin: 0px;">
+                    <span class="fa fa-eye"></span>
+                </a>
+            {% endif %}
+            {% if display_browse_button %}
+                <button type="button" class="btn btn-default resource-browse" title="Ressources" data-toggle="tooltip" style="margin: 0px;">
+                    <span class="fa fa-folder-open"></span>
+                </button>
+            {% endif %}
+            {% if display_download_button %}
+                <button type="button" class="btn btn-default resource-download" title="Téléchargement" data-toggle="tooltip" style="margin: 0px;">
+                    <span class="fa fa-file"></span>
+                </button>
+            {% endif %}
+            </span>
+        </div>
+        {% endif %}
+
         {% javascripts debug=false filter='jsmin' output='js/claroline/resourceinput.js'
+            'bundles/fosjsrouting/js/router.js'
+            'bundles/clarolinecore/js/resource/manager/manager.js'
             'bundles/clarolinecore/js/resourceinput.js'
         %}
-            <script type="text/javascript" src="{{ asset_url }}"></script>
+        <script type="text/javascript" src="{{ asset_url }}"></script>
         {% endjavascripts %}
+        <script type="text/javascript">
+            (function($) {
+                "use strict";
+
+                $(function() {
+                    window.Claroline.ResourcePicker.initialize("{{ id }}");
+                });
+            })(jQuery);
+        </script>
     {% endspaceless %}
 {% endblock %}

--- a/Resources/views/Form/resource_picker.html.twig
+++ b/Resources/views/Form/resource_picker.html.twig
@@ -12,7 +12,7 @@
             <span class="input-group-btn">
             {% if display_view_button %}
                 <a  class="btn btn-default disabled resource-view" title="Voir" data-toggle="tooltip" target="_blank" href="" style="margin: 0px;">
-                    <span class="fa fa-eye"></span>
+                    <span class="fa fa-external-link"></span>
                 </a>
             {% endif %}
             {% if display_browse_button %}

--- a/Resources/views/Form/resource_picker.html.twig
+++ b/Resources/views/Form/resource_picker.html.twig
@@ -29,13 +29,6 @@
         </div>
         {% endif %}
 
-        {% javascripts debug=false filter='jsmin' output='js/claroline/resourceinput.js'
-            'bundles/fosjsrouting/js/router.js'
-            'bundles/clarolinecore/js/resource/manager/manager.js'
-            'bundles/clarolinecore/js/resourceinput.js'
-        %}
-        <script type="text/javascript" src="{{ asset_url }}"></script>
-        {% endjavascripts %}
         <script type="text/javascript">
             (function($) {
                 "use strict";

--- a/Resources/views/Form/user_picker.html.twig
+++ b/Resources/views/Form/user_picker.html.twig
@@ -47,12 +47,6 @@
             </span>
         </div>
 
-        {% javascripts debug=false filter='jsmin' output='js/claroline/user_picker.js'
-            'bundles/clarolinecore/js/user/user_picker.js'
-        %}
-            <script type="text/javascript" src="{{ asset_url }}"></script>
-        {% endjavascripts %}
-
         <script type="text/javascript">
             {% set excludedUserIds = [] %}
             {% set forcedUserIds = [] %}

--- a/Resources/views/Form/user_picker.html.twig
+++ b/Resources/views/Form/user_picker.html.twig
@@ -46,7 +46,13 @@
                 </span>
             </span>
         </div>
-        
+
+        {% javascripts debug=false filter='jsmin' output='js/claroline/user_picker.js'
+            'bundles/clarolinecore/js/user/user_picker.js'
+        %}
+            <script type="text/javascript" src="{{ asset_url }}"></script>
+        {% endjavascripts %}
+
         <script type="text/javascript">
             {% set excludedUserIds = [] %}
             {% set forcedUserIds = [] %}

--- a/Resources/views/Layout/javascripts.html.twig
+++ b/Resources/views/Layout/javascripts.html.twig
@@ -107,7 +107,6 @@
     'bundles/clarolinecore/js/resource/manager/manager.js'
     'bundles/clarolinecore/js/home/home.js'
     'bundles/clarolinecore/js/locale.js'
-    'bundles/clarolinecore/js/resourceinput.js'
     'bundles/clarolinecore/js/utilities.js'
     'bundles/clarolinecore/js/startup.js'
 %}

--- a/Resources/views/Layout/javascripts.html.twig
+++ b/Resources/views/Layout/javascripts.html.twig
@@ -107,8 +107,10 @@
     'bundles/clarolinecore/js/resource/manager/manager.js'
     'bundles/clarolinecore/js/home/home.js'
     'bundles/clarolinecore/js/locale.js'
+    'bundles/clarolinecore/js/resourceinput.js'
     'bundles/clarolinecore/js/utilities.js'
     'bundles/clarolinecore/js/startup.js'
+    'bundles/clarolinecore/js/user/user_picker.js'
 %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
 {% endjavascripts %}

--- a/Resources/views/Layout/javascripts.html.twig
+++ b/Resources/views/Layout/javascripts.html.twig
@@ -110,7 +110,6 @@
     'bundles/clarolinecore/js/resourceinput.js'
     'bundles/clarolinecore/js/utilities.js'
     'bundles/clarolinecore/js/startup.js'
-    'bundles/clarolinecore/js/user/user_picker.js'
 %}
     <script type="text/javascript" src="{{ asset_url }}"></script>
 {% endjavascripts %}


### PR DESCRIPTION
Making the modification of this form field a little simpler using html template instead of javascript.
I was able to move some form field class in the right directory too.

I change the icon for the view action, [fa-external-link](http://fontawesome.io/icon/external-link/) instead of [fa-eye](http://fontawesome.io/icon/eye/).