### PR TITLE
Add some state messages for package on package management page

### DIFF
--- a/Resources/translations/platform.en.yml
+++ b/Resources/translations/platform.en.yml
@@ -1132,3 +1132,5 @@ refresh_explanation: |
 platform_refresh_confirm: Do you really want to refresh the platform files ?
 is_not_writable_recursive: 'is not writable recursively'
 test_repository_activated: 'Test repositories are activated'
+not_managed_by_claroline_repository: 'State unavailable'
+update_impossible: 'Update impossible'

--- a/Resources/translations/platform.es.yml
+++ b/Resources/translations/platform.es.yml
@@ -1129,3 +1129,5 @@ refresh_explanation: refresh_explanation
 platform_refresh_confirm: platform_refresh_confirm
 is_not_writable_recursive: is_not_writable_recursive
 test_repository_activated: 'test_repository_activated'
+not_managed_by_claroline_repository: 'Estado indisponible'
+update_impossible: 'Actualización imposible'

--- a/Resources/translations/platform.fr.yml
+++ b/Resources/translations/platform.fr.yml
@@ -1132,3 +1132,5 @@ refresh_explanation: |
 platform_refresh_confirm: Êtes-vous sûr de vouloir raffraîchir les fichiers de la plateforme ?
 is_not_writable_recursive: 'et ses sous dossiers ne sont pas accessibles en écriture'
 test_repository_activated: 'Les dépôts de test sont activés'
+not_managed_by_claroline_repository: 'Etat indisponible'
+update_impossible: 'Mise à jour impossible'

--- a/Resources/views/macros.html.twig
+++ b/Resources/views/macros.html.twig
@@ -199,10 +199,14 @@
                                     <span class="badge alert-success">
                                         {{ 'up_to_date'|trans({}, 'platform') }}
                                     </span>
+                                {% else %}
+                                    <span class="badge alert-danger">
+                                        {{ 'update_impossible'|trans({}, 'platform') }}
+                                    </span>
                                 {% endif %}
                             {% else %}
                                 <span class="badge alert-danger">
-                                    {{ 'outdated'|trans({}, 'platform') }}
+                                    {{ 'not_managed_by_claroline_repository'|trans({}, 'platform') }}
                                 </span>
                             {% endif %}
                         {% else %}


### PR DESCRIPTION
For package when update is impossible because of the requirements not respected we display 'Update impossible'.
For package that the claroline repository isn't aware of we display 'State unavailable'.