### PR TITLE
add an option in CopyEvent to choose if we want to publish or not the copied resource

### DIFF
--- a/Event/CopyResourceEvent.php
+++ b/Event/CopyResourceEvent.php
@@ -27,6 +27,12 @@ class CopyResourceEvent extends Event implements DataConveyorEventInterface
     private $isPopulated = false;
 
     /**
+     * If true the copy will be published
+     * @var bool
+     */
+    private $publish = false;
+
+    /**
      * Constructor.
      *
      * @param \Claroline\CoreBundle\Entity\Resource\AbstractResource $resource
@@ -36,6 +42,11 @@ class CopyResourceEvent extends Event implements DataConveyorEventInterface
     {
         $this->resource = $resource;
         $this->parent   = $parent;
+
+        // By default, use the same published state as the copied node
+        if ($this->resource->getResourceNode()) {
+            $this->publish = $this->resource->getResourceNode()->isPublished();
+        }
     }
 
     /**
@@ -81,5 +92,19 @@ class CopyResourceEvent extends Event implements DataConveyorEventInterface
     public function isPopulated()
     {
         return $this->isPopulated;
+    }
+
+    /**
+     * Is the copied resource need to be published or not ?
+     * @return bool
+     */
+    public function getPublish()
+    {
+        return $this->publish;
+    }
+
+    public function setPublish($publish)
+    {
+        $this->publish = $publish;
     }
 }

--- a/Manager/ResourceManager.php
+++ b/Manager/ResourceManager.php
@@ -772,6 +772,10 @@ class ResourceManager
 
             $copy = $event->getCopy();
             $newNode = $this->copyNode($node, $parent, $user, $withRights, $rights, $index);
+
+            // Set the published state
+            $newNode->setPublished($event->getPublish());
+
             $copy->setResourceNode($newNode);
 
             if ($node->getResourceType()->getName() == 'directory' &&


### PR DESCRIPTION
To speed up and simplify the copy of the Paths, we need to copy them in an unpublished state. So correct Activity will be recreated when publishing the copied Path.

If we can't do that, we need to copy all Resources manually in order to map the old ID and the new ones to restore all the relations.

As it's an urgent bug fix for our Users, can you please create a tag after merging this please ?

Thanks.