### PR TITLE
datetimepicker

### DIFF
--- a/Form/Field/DateTimePickerType.php
+++ b/Form/Field/DateTimePickerType.php
@@ -11,7 +11,6 @@ namespace Claroline\CoreBundle\Form\Field;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
-use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
@@ -57,5 +56,4 @@ class DateTimePickerType extends AbstractType
     {
         return 'datetimepicker';
     }
-
-} 
+}

--- a/Resources/views/Form/date_time_picker.html.twig
+++ b/Resources/views/Form/date_time_picker.html.twig
@@ -8,13 +8,13 @@
 {% endblock custom_widget_attributes %}
 
 
-{% block  datetimepicker_row %}
-    <div class="{% if errors %}has-error{% endif %}">
+{% block datetimepicker_row %}
+    <div class="{% if errors|length > 0 %}has-error{% endif %}">
         {% spaceless %}
             {{ form_errors(form,{}) }}
             {{ form_label(form,{}) }}
             {{ form_widget(form,{})  }}
-        {%  endspaceless %}
+        {% endspaceless %}
     </div>
 {% endblock %}
 


### PR DESCRIPTION
* fix datepicker has-error condition (condition was always verified, even if error was empty)
* remove useless use statement. 

:rabbit: 