### PR TITLE
Add resource publication change event

### DIFF
--- a/Entity/Resource/AbstractResource.php
+++ b/Entity/Resource/AbstractResource.php
@@ -13,7 +13,9 @@ namespace Claroline\CoreBundle\Entity\Resource;
 
 use Doctrine\ORM\Mapping as ORM;
 
-/** @ORM\MappedSuperclass */
+/**
+ * @ORM\MappedSuperclass
+ */
 abstract class AbstractResource
 {
     /**
@@ -29,43 +31,65 @@ abstract class AbstractResource
      */
     protected $resourceNode;
 
-    protected $name = '';
+    protected $name = ''; // should be removed ?
 
-    //to remove ?
     protected $mimeType;
 
-    public function setResourceNode(ResourceNode $resourceNode)
-    {
-        $this->resourceNode = $resourceNode;
-    }
-
-    public function getResourceNode()
-    {
-        return $this->resourceNode;
-    }
-
+    /**
+     * @return integer
+     */
     public function getId()
     {
         return $this->id;
     }
 
-    //for forms (otherwise name won't exist)
-    //@todo this should be removed
+    /**
+     * @param ResourceNode $resourceNode
+     */
+    public function setResourceNode(ResourceNode $resourceNode)
+    {
+        $this->resourceNode = $resourceNode;
+    }
+
+    /**
+     * @return ResourceNode
+     */
+    public function getResourceNode()
+    {
+        return $this->resourceNode;
+    }
+
+    /**
+     * For forms (otherwise name won't exist)
+     *
+     * TODO: this should be removed
+     *
+     * @return string
+     */
     public function getName()
     {
         return $this->name;
     }
 
+    /**
+     * @param string $name
+     */
     public function setName($name)
     {
         $this->name = $name;
     }
 
+    /**
+     * @return string
+     */
     public function getMimeType()
     {
         return $this->mimeType;
     }
 
+    /**
+     * @param string $mimeType
+     */
     public function setMimeType($mimeType)
     {
         $this->mimeType = $mimeType;

--- a/Event/PublicationChangeEvent.php
+++ b/Event/PublicationChangeEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Claroline\CoreBundle\Event;
+
+use Claroline\CoreBundle\Entity\Resource\AbstractResource;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event dispatched when the publication status of a
+ * resource node is modified.
+ */
+class PublicationChangeEvent extends Event
+{
+    private $resource;
+
+    /**
+     * @param AbstractResource $resource
+     */
+    public function __construct(AbstractResource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * @return AbstractResource
+     */
+    public function getResource()
+    {
+        return $this->resource;
+    }
+}


### PR DESCRIPTION
A plugin may need to take action when a resource is published/unpublished. This PR adds a core event for that scenario.

Note: changes to `AbstractResource` are unrelated (just docblock fixes) 