### PR TITLE
Fixes video stream bug on Chrome

### DIFF
--- a/Controller/FileController.php
+++ b/Controller/FileController.php
@@ -50,6 +50,8 @@ class FileController extends Controller
                 readfile($path);
             }
         );
+        
+        $this->get('session')->save();
 
         $response->headers->set('Content-Type', $node->getMimeType());
 


### PR DESCRIPTION
This fixes a bug that occurs when you have multiple mp4 videos on the same page in Chrome.

The problem is that Chrome tries to start multiple PHP sessions to stream videos in parallel when they are file ressources.
Playing the first video works, but playing a second will result in a pending stream and often a crashed browser.

PHP blocks the session while the stream response is not finished.

The fix is to free the PHP Session as early as possible.