### PR TITLE
Add asset path function

### DIFF
--- a/Resources/config/suggested/framework_dev.yml
+++ b/Resources/config/suggested/framework_dev.yml
@@ -7,4 +7,4 @@ framework:
     session:
         save_path: %kernel.root_dir%/sessions
     templating:
-        assets_base_url: "http://localhost:8080"
+        assets_base_url: http://localhost:8080

--- a/Resources/views/Administration/Parameters/appearanceForm.html.twig
+++ b/Resources/views/Administration/Parameters/appearanceForm.html.twig
@@ -43,7 +43,7 @@
                     {% for logo in logos %}
                         <div style="height:80px" class="alert {% if config.getParameter('logo') == logo %}alert-info{% else %}alert-warning{% endif %} content-4 pointer-hand logo" data-logo="{{ logo }}">
                             <button type="button" class="close" aria-hidden="true">&times;</button>
-                            <img src="{{ asset("") ~ "uploads/logos/" ~ logo }}" height="35" alt="Logo {{loop.index}}">
+                            <img src="{{ getAssetPath() ~ '/uploads/logos/' ~ logo }}" height="35" alt="Logo {{loop.index}}">
                         </div>
                     {% endfor %}
                     <input type="hidden" name="selectlogo" {% if config.getParameter('logo') != "" %}value="{{ config.getParameter('logo') }}"{% endif %}>

--- a/Resources/views/Exception/layout.html.twig
+++ b/Resources/views/Exception/layout.html.twig
@@ -3,7 +3,7 @@
 {% block stylesheets %}
 
     {% if config.getParameter('theme') != '' %}
-        <link rel="stylesheet" href="{{ asset('') ~ 'themes/' ~ config.getParameter('theme') ~ '/bootstrap.css' }}" screen="media" />
+        <link rel="stylesheet" href="{{ getAssetPath() ~ '/themes/' ~ config.getParameter('theme') ~ '/bootstrap.css' }}" screen="media" />
     {% endif %}
 
     <link rel="stylesheet" href="{{ asset('packages/font-awesome/css/font-awesome.min.css') }}" screen="media" />
@@ -32,13 +32,13 @@
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    {% if config.getParameter('logo') != "" %}
+                    {% if config.getParameter('logo') != '' %}
                         <a class="navbar-brand logo" href="{{ path('claro_index') }}">
-                            <img src="{{ asset("") ~ "uploads/logos/" ~ config.getParameter('logo') }}" height="35"
+                            <img src="{{ getAssetPath() ~ '/uploads/logos/' ~ config.getParameter('logo') }}" height="35"
                                 {% if config.getParameter('name') != "" %}alt="{{ config.getParameter('name') }}"{% endif %}>
                         </a>
                     {% endif %}
-                    {% if config.getParameter('name') != "" and config.getParameter('nameActive') %}
+                    {% if config.getParameter('name') != '' and config.getParameter('nameActive') %}
                         <a class="navbar-brand" href="{{ path('claro_index') }}">
                             {{ config.getParameter('name') }}
                         </a>

--- a/Resources/views/Home/menuSettings.html.twig
+++ b/Resources/views/Home/menuSettings.html.twig
@@ -97,13 +97,13 @@
                                 <span class="icon-bar"></span>
                                 <span class="icon-bar"></span>
                             </button>
-                            {% if config.getParameter('logo') != "" %}
+                            {% if config.getParameter('logo') != '' %}
                                 <a class="navbar-brand logo" href="{{ path('claro_index') }}">
-                                    <img src="{{ asset("") ~ "uploads/logos/" ~ config.getParameter('logo') }}" height="35"
+                                    <img src="{{ getAssetPath() ~ '/uploads/logos/' ~ config.getParameter('logo') }}" height="35"
                                         {% if config.getParameter('name') != "" %}alt="{{ config.getParameter('name') }}"{% endif %}>
                                 </a>
                             {% endif %}
-                            {% if config.getParameter('name') != "" and config.getParameter('nameActive') %}
+                            {% if config.getParameter('name') != '' and config.getParameter('nameActive') %}
                                 <a class="navbar-brand" href="{{ path('claro_index') }}">
                                     {{ config.getParameter('name') }}
                                 </a>

--- a/Resources/views/Layout/stylesheets.html.twig
+++ b/Resources/views/Layout/stylesheets.html.twig
@@ -1,14 +1,9 @@
 {% if config.getParameter('theme') is defined and asset_exists('themes/' ~ config.getParameter('theme') ~ '/bootstrap.css') %}
     {# from theme #}
-    {% if app.environment == 'dev' %}
-        {% set prefix = '/' %}
-    {% else %}
-        {% set prefix = '' %}
-    {% endif %}
-    {% set themeCSS = asset('') ~ prefix ~ 'themes/' ~ config.getParameter('theme') ~ '/bootstrap.css' %}
+    {% set themeCSS = getAssetPath() ~ '/themes/' ~ config.getParameter('theme') ~ '/bootstrap.css' %}
 {% else %}
     {# default #}
-    {% set themeCSS = asset('') ~ prefix ~ 'themes/' ~ 'claroline' ~ '/bootstrap.css' %}
+    {% set themeCSS = getAssetPath() ~ '/themes/claroline/bootstrap.css' %}
 {% endif %}
 
 {# Angular UI #}

--- a/Resources/views/Layout/topBar.html.twig
+++ b/Resources/views/Layout/topBar.html.twig
@@ -9,13 +9,13 @@
                     <span class="icon-bar"></span>
                     <span class="icon-bar"></span>
                 </button>
-                {% if config.getParameter('logo') != "" %}
+                {% if config.getParameter('logo') != '' %}
                     <a class="navbar-brand logo" href="{{ path('claro_index') }}" title="{{ 'home' | trans({}, "platform") }}">
-                        <img src="{{ asset("") ~ "uploads/logos/" ~ config.getParameter('logo') }}" height="35"
+                        <img src="{{ getAssetPath() ~ '/uploads/logos/' ~ config.getParameter('logo') }}" height="35"
                             {% if config.getParameter('name') != "" %}alt="{{ config.getParameter('name') }}"{% endif %}>
                     </a>
                 {% endif %}
-                {% if config.getParameter('name') != "" and config.getParameter('nameActive') %}
+                {% if config.getParameter('name') != '' and config.getParameter('nameActive') %}
                     <a class="navbar-brand" href="{{ path('claro_index') }}">
                         {{ config.getParameter('name') }}
                     </a>
@@ -51,7 +51,7 @@
                         {% else %}
                             {{ block('login') }}
                         {% endif %}
-                        
+
                         {% if showHelpButton %}
                             <li>
                                 <a href="{{ helpUrl }}">

--- a/Resources/views/Resource/managerParameters.json.twig
+++ b/Resources/views/Resource/managerParameters.json.twig
@@ -9,7 +9,7 @@
 {
     "currentUsername": "{{ currentUsername }}",
     "currentUserId": "{{ currentUserId }}",
-    "webPath": "{{ asset('') }}",
+    "webPath": "{{ getAssetPath() }}",
     "language": "{{ app.request.locale }}",
     "zoom": "{{ app.session.get('zoom') }}",
     "pickerDirectoryId": "{{ directoryId }}",

--- a/Resources/views/Resource/thumbnail.html.twigjs
+++ b/Resources/views/Resource/thumbnail.html.twigjs
@@ -15,7 +15,7 @@
 </div>
 
 <div class="clickable-node node-element{% if not node.published %} unpublished{% endif %}" id="node-element-{{ node.id }}"
-    style="background-image: url('{{ webRoot }}{{ node.large_icon }}');"
+    style="background-image: url('{{ webRoot }}/{{ node.large_icon }}');"
     data-id="{{ node.id }}"
     data-type="{{ node.type }}"
     data-mime-type="{{ node.mime_type }}"

--- a/Resources/views/Tool/desktop/resource_manager/resources.html.twig
+++ b/Resources/views/Tool/desktop/resource_manager/resources.html.twig
@@ -26,7 +26,7 @@
                 "parentElement": $('div.section-content .panel'),
                 "breadcrumbElement": $('ul.breadcrumb'),
                 "isWorkspace": false,
-                "webPath": "{{ asset('') }}",
+                "webPath": "{{ getAssetPath() }}",
                 "language": "{{ app.request.locale }}",
                 "zoom": "{{ resourceZoom }}",
                 "pickerDirectoryId": "{{ app.session.get('pickerDirectoryId', '0') }}",

--- a/Resources/views/Tool/workspace/resource_manager/resources.html.twig
+++ b/Resources/views/Tool/workspace/resource_manager/resources.html.twig
@@ -30,7 +30,7 @@
                 "parentElement": $('div.section-content .panel'),
                 "breadcrumbElement": $('ul.breadcrumb'),
                 "isWorkspace": true,
-                "webPath": "{{ asset('') }}",
+                "webPath": "{{ getAssetPath() }}",
                 "language": "{{ app.request.locale }}",
                 "zoom": "{{ resourceZoom }}",
                 "pickerDirectoryId": "{{ app.session.get('pickerDirectoryId', '0') }}",

--- a/Resources/views/Widget/embed/widget.html.twig
+++ b/Resources/views/Widget/embed/widget.html.twig
@@ -2,7 +2,7 @@
 
 {% block stylesheets %}
     {% if config.getParameter('theme') != '' %}
-        <link rel="stylesheet" href="{{ asset('') ~ 'themes/' ~ config.getParameter('theme') ~ '/bootstrap.css' }}" screen="media" />
+        <link rel="stylesheet" href="{{ getAssetPath() ~ '/themes/' ~ config.getParameter('theme') ~ '/bootstrap.css' }}" screen="media" />
     {% endif %}
 
     <link rel='stylesheet' type='text/css' href='{{ asset('packages/font-awesome/css/font-awesome.min.css') }}'/>

--- a/Twig/BaseUriExtension.php
+++ b/Twig/BaseUriExtension.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Twig;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Bundle\FrameworkBundle\Templating\Helper\AssetsHelper;
+
+/**
+ * @DI\Service
+ * @DI\Tag("twig.extension")
+ */
+class BaseUriExtension extends \Twig_Extension
+{
+    private $assetsHelper;
+
+    /**
+     * @DI\InjectParams({
+     *     "helper" = @DI\Inject("templating.helper.assets")
+     * })
+     */
+    public function __construct(AssetsHelper $helper)
+    {
+        $this->assetsHelper = $helper;
+    }
+
+    public function getFunctions()
+    {
+        return ['getAssetPath' => new \Twig_Function_Method($this, 'getAssetPath')];
+    }
+
+    public function getName()
+    {
+        return 'base_uri_extension';
+    }
+
+    /**
+     * Returns the URI under which assets are served, without any trailing slash.
+     *
+     * @return string
+     */
+    public function getAssetPath()
+    {
+        $path = $this->assetsHelper->getUrl('');
+
+        if ($path[strlen($path) - 1] === '/') {
+            $path = rtrim($path, '/');
+        }
+
+        return $path;
+    }
+}


### PR DESCRIPTION
Adds a `getAssetPath` twig function, replacing calls like `asset('')` to get the web directory uri. The returned uri never has a trailing '/', so concats are predictable.