### PR TITLE
Create separate path for webpack assets + fix hot reload

### DIFF
--- a/Resources/config/suggested/framework_dev.yml
+++ b/Resources/config/suggested/framework_dev.yml
@@ -6,5 +6,3 @@ framework:
         only_exceptions: false
     session:
         save_path: %kernel.root_dir%/sessions
-    templating:
-        assets_base_url: http://localhost:8080

--- a/Resources/scripts/lib/webpack.js
+++ b/Resources/scripts/lib/webpack.js
@@ -25,7 +25,7 @@ function configure(rootDir, packages, isWatchMode) {
   // all entries are compiled in the web/dist directory
   const output = {
     path: path.resolve(rootDir, 'web/dist'),
-    publicPath: 'http://localhost:8080/',
+    publicPath: 'http://localhost:8080/dist',
     filename: '[name].js'
   }
 

--- a/Resources/views/Administration/Organization/index.html.twig
+++ b/Resources/views/Administration/Organization/index.html.twig
@@ -17,6 +17,6 @@
 
 {% block javascripts %}
     {{ parent() }}
-    <script src="{{ asset('dist/claroline-core-organization-management.js') }}"></script>
-    
+    <script src="{{ hotAsset('dist/claroline-core-organization-management.js') }}"></script>
+
 {% endblock %}

--- a/Resources/views/Administration/Users/index.html.twig
+++ b/Resources/views/Administration/Users/index.html.twig
@@ -20,5 +20,5 @@
 
 {% block javascripts %}
     {{ parent() }}
-    <script src="{{ asset('dist/claroline-core-user-management.js') }}"></script>
+    <script src="{{ hotAsset('dist/claroline-core-user-management.js') }}"></script>
 {% endblock %}

--- a/Resources/views/Layout/javascripts.html.twig
+++ b/Resources/views/Layout/javascripts.html.twig
@@ -169,7 +169,3 @@
         });
     });
 </script>
-
-{% if app.environment == 'dev' %}
-    <script src="{{ asset('webpack-dev-server.js') }}"></script>
-{% endif %}

--- a/Twig/WebpackExtension.php
+++ b/Twig/WebpackExtension.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of the Claroline Connect package.
+ *
+ * (c) Claroline Consortium <consortium@claroline.net>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Claroline\CoreBundle\Twig;
+
+use JMS\DiExtraBundle\Annotation as DI;
+use Symfony\Bridge\Twig\Extension\AssetExtension;
+
+/**
+ * @DI\Service
+ * @DI\Tag("twig.extension")
+ */
+class WebpackExtension extends \Twig_Extension
+{
+    private $assetExtension;
+    private $environment;
+
+    /**
+     * @DI\InjectParams({
+     *     "extension"      = @DI\Inject("twig.extension.assets"),
+     *     "environment"    = @DI\Inject("%kernel.environment%")
+     * })
+     *
+     * @param AssetExtension $extension
+     */
+    public function __construct(AssetExtension $extension, $environment)
+    {
+        $this->assetExtension = $extension;
+        $this->environment = $environment;
+    }
+
+    public function getFunctions()
+    {
+        return [
+            'hotAsset' => new \Twig_Function_Method($this, 'hotAsset')
+        ];
+    }
+
+    public function getName()
+    {
+        return 'webpack_extension';
+    }
+
+    public function hotAsset($path)
+    {
+        if ($this->environment === 'dev') {
+            return "http://localhost:8080/{$path}";
+        }
+
+        return $this->assetExtension->getAssetUrl($path);
+    }
+}


### PR DESCRIPTION
This PR adds a new `hotAsset` twig function making the asset point on the webpack server in dev environment. Advantages:

- only specific assets are served by webpack, other assets are served by the usual web server
- cross-domain issues are avoided for non-webpack stuff